### PR TITLE
Refine trajectory evidence and harden Harbor evolution runtime

### DIFF
--- a/META_AGENTS.md
+++ b/META_AGENTS.md
@@ -54,19 +54,39 @@ repair only constrains observable candidate changes; it is not a host sandbox.
 ## `runner: harbor`: isolated agent with artifact return
 
 The Harbor runner builds a disposable writable experiment workspace at
-`/app/workspace`. It contains the selected parent, self-contained Git history,
-configuration, archive, and prior/current run evidence, so the agent can inspect
-and edit it like a local checkout. The real host workspace is never mounted.
+`/app/task/workspace`. Gate visibility is controlled by
+`operators.meta_agent.expose_gate_data`, which must be a boolean and defaults to
+`false`.
+
+With `expose_gate_data: false`, the task receives the selected parent,
+configuration, a clean Git baseline, and the `rollout`, `trace_analyzer`, and
+`feedback` inputs from current and prior generations. Evaluator files, task
+partitions, archive/receipt records, selection artifacts, gate/record
+directories, and gate/sealed evaluations are not copied. The clean Git baseline
+supports normal `git diff` and `git status` use without retaining sensitive
+paths in object history.
+
+With `expose_gate_data: true`, the task instead receives the full Git history,
+evaluator and split files, archive/receipt records, and the retained run tree,
+including gate/sealed evaluations. Enable this only for methods whose intended
+feedback contract includes those results. The real host workspace is never
+mounted in either mode.
+
+The bundled recipes make this choice explicitly: A-Evolve, GEPA, and hill
+climb use `false` because gate is held out from mutation; AHE and HyperAgents
+use `true` because their recipe definitions optimize on retained
+full-benchmark evaluations rather than a held-out gate.
 Harbor returns the complete disposable workspace; the runner compares it with a
 trusted pre-run manifest, rejects protected changes, symlinks, and special files,
 then transactionally imports only configured `editable_roots`. Changes to Git
-metadata, archive/runtime evidence, and evaluation receipts are discarded.
+metadata and runtime evidence are discarded.
 AHE imports only `target`; HyperAgents imports `target` and `operators`.
 
 ```yaml
 meta_agent:
   variant: hyperagents
   runner: harbor
+  expose_gate_data: false
   agent: mini-swe-agent
   model: openai/gpt-5.4
   environment: docker
@@ -79,6 +99,7 @@ meta_agent:
 Useful optional keys are:
 
 - `agent`: Harbor built-in name, `module.path:ClassName`, or supported ACP shorthand;
+- `expose_gate_data`: expose full evaluator/archive/run history, including gate/sealed data (defaults to `false`);
 - `editable_roots`: top-level repository trees eligible for transactional import (defaults to `[target]`);
 - `model`: model identifier expected by that Harbor adapter;
 - `agent_kwargs`: mapping converted to repeated Harbor `--agent-kwarg key=value` flags;

--- a/TRACE_ANALYZER.md
+++ b/TRACE_ANALYZER.md
@@ -23,6 +23,7 @@ operators:
 | `failure_patterns` | Aggregate metrics, verifier-grounded failure signatures, representatives, and passing behavior to preserve. |
 | `failed_traces` | Aggregate metrics plus detailed failed/agent-error execution records. |
 | `trace_browser` | A small metrics summary and filesystem instructions for raw traces, source, and prior generations. |
+| `trajectory_only` | A-Evolve-style behavior-only signals, failure-focused compression, and LLM proxy verdicts; no evaluator labels, task text, or raw-case paths. |
 | `execution_records` | Complete per-case input/output, ordered actions, tool results, verifier feedback, metrics, and history pointers. |
 | `utility_metrics` | Per-task downstream utility and the current editable source; trajectories are not emphasized. |
 
@@ -51,7 +52,7 @@ The analyzer reads:
 - prior run metrics and lineage through the feedback history generated after
   analysis.
 
-Every variant writes the same auditable base files:
+Most variants write the same auditable base files:
 
 - `trace_analyzer/evidence/raw_traces.jsonl`;
 - `trace_analyzer/evidence/failure_records.json`;
@@ -62,14 +63,28 @@ Every variant writes the same auditable base files:
 - `trace_analyzer/evidence/manifest.json`;
 - `trace_analyzer/evidence/selected.md`.
 
+`trajectory_only` is deliberately narrower. It first asks an isolated,
+read-only LLM judge to estimate each trajectory's score, category, outcome, and
+failure reason using the compressed behavior alone. It then writes only
+`manifest.json`, `trajectory_only.json`, and `selected.md`; it does not
+place reward, outcome, verifier output, task input, or `raw_traces.jsonl` in
+the meta-agent evidence directory.
+
 `selected.md` is copied into `feedback/evidence/selected.md` and its body is
 injected into the meta-agent prompt. Raw files remain available through
 `$EVOLVE_RUN_DIR/trace_analyzer/evidence/`.
 
+For `trajectory_only`, the A-Evolve meta-agent receives only the selected
+behavior view. Its Harbor workspace bundle omits `archive.jsonl` and `runs/`,
+so evaluator labels cannot be recovered by filesystem discovery.
+
 ## Fidelity boundary
 
-The analyzer is deterministic: it parses, filters, clusters, serializes, and
-truncates existing rollout facts without another model call. The later meta-agent
-model performs reflection and editing. These variants define trace-retention
-interfaces; they do not reproduce the full search algorithms of the papers that
-motivated the former profiles.
+All variants except `trajectory_only` are deterministic: they parse, filter,
+cluster, serialize, and truncate existing rollout facts without another model
+call. `trajectory_only` intentionally adds the same separate behavior-only
+proxy-judge stage used by the official A-Evolve path. The judge may use the
+configured meta-agent model but runs in an empty read-only Harbor task and
+cannot inspect evaluator labels or the candidate workspace. These variants
+define trace-retention interfaces; they do not reproduce every surrounding
+search capability of the papers that motivated the former profiles.

--- a/containers/meta-agent/Dockerfile
+++ b/containers/meta-agent/Dockerfile
@@ -1,7 +1,31 @@
 FROM ubuntu:latest
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends build-essential ca-certificates curl git python3 python-is-python3 \
+    && apt-get install -y --no-install-recommends \
+        bash \
+        build-essential \
+        ca-certificates \
+        coreutils \
+        curl \
+        diffutils \
+        file \
+        findutils \
+        git \
+        jq \
+        less \
+        openssh-client \
+        patch \
+        procps \
+        python3 \
+        python3-pip \
+        python3-venv \
+        python-is-python3 \
+        ripgrep \
+        rsync \
+        sed \
+        tree \
+        unzip \
+        zip \
     && rm -rf /var/lib/apt/lists/*
 RUN curl -LsSf https://astral.sh/uv/0.7.13/install.sh | sh
 ENV PATH="/root/.local/bin:${PATH}"

--- a/containers/meta-agent/Dockerfile
+++ b/containers/meta-agent/Dockerfile
@@ -33,5 +33,6 @@ RUN uv tool install --python 3.13 --with fastapi --with orjson mini-swe-agent
 RUN mv /root/.local/bin/uv /root/.local/bin/uv-real
 COPY uv-wrapper /root/.local/bin/uv
 RUN chmod 755 /root/.local/bin/uv
+RUN git config --system --add safe.directory /app/task/workspace
 
 WORKDIR /app

--- a/library/PROTOCOL.md
+++ b/library/PROTOCOL.md
@@ -188,7 +188,7 @@ may appear in recipe prose, but `variant:` values point to these files:
 
 - select: `greedy`, `random`, `score_weighted`, `newest`, `pareto`
 - rollout: `failure_focused`, `harbor`, `noop`
-- trace_analyzer: `failure_patterns`, `failed_traces`, `trace_browser`, `execution_records`, `gepa`, `utility_metrics`
+- trace_analyzer: `failure_patterns`, `failed_traces`, `trace_browser`, `trajectory_only`, `execution_records`, `gepa`, `utility_metrics`
 - meta_agent: `aevolve`, `ahe`, `gepa`, `hyperagents` (`runner`: `local` or `harbor`)
 - validate: `hyperagents`, `minibatch_improvement`
 - gate: `hillclimb`, `parent_eligible`

--- a/library/README.md
+++ b/library/README.md
@@ -22,7 +22,7 @@ See `DESIGN.md` §7 for the full rationale. In short:
 library/
 ├─ select/   greedy · newest · pareto · random · score_weighted
 ├─ rollout/  failure_focused · harbor · noop
-├─ trace_analyzer/ failure_patterns · failed_traces · trace_browser · execution_records · gepa · utility_metrics
+├─ trace_analyzer/ failure_patterns · failed_traces · trace_browser · trajectory_only · execution_records · gepa · utility_metrics
 ├─ meta_agent/ aevolve · ahe · gepa · hyperagents
 │  ├─ support/  shared evidence loading
 │  └─ runners/ local · harbor

--- a/library/meta_agent/aevolve.py
+++ b/library/meta_agent/aevolve.py
@@ -14,6 +14,11 @@ from evolve.frozen import sdk
 from evolve.frozen.interfaces import MetaAgentOperator, MetaAgentResult, OperatorContext
 from evolve.patching import create_candidate_patch, load_surface_policy, patch_parent_ref
 from library.meta_agent.runners import run_agent, runner_name
+from library.meta_agent.support.evidence import load_feedback
+from library.meta_agent.support.workspace import workspace_contract
+
+DEFAULT_INLINE_EVIDENCE_CHARS = 50_000
+TRAJECTORY_ONLY_VARIANT = "trajectory_only"
 
 AEVOLVE_SYSTEM_PROMPT = """# A-Evolve Workspace Improvement
 
@@ -163,19 +168,8 @@ def _draft_section(drafts: list[dict[str, str]]) -> str:
     return "\n\n".join(f"#### Draft: {draft['name']}\n```markdown\n{draft['content']}\n```" for draft in drafts)
 
 
-def _permissions(config: dict[str, Any], paths: dict[str, str]) -> list[str]:
-    permissions: list[str] = []
-    if _enabled(config, "evolve_prompts", True):
-        permissions.append(f"- You CAN modify `{paths['prompt']}`")
-    if _enabled(config, "evolve_skills", True):
-        permissions.append(f"- You CAN create, modify, or delete skills under `{paths['skills']}/`")
-    if _enabled(config, "evolve_memory", True):
-        permissions.append(f"- You CAN add or prune entries under `{paths['memory']}/`")
-    if _enabled(config, "evolve_tools", False):
-        permissions.append(f"- You CAN create or modify tools under `{paths['tools']}/`")
-    if not permissions:
-        raise ValueError("A-Evolve meta-agent has no enabled mutable workspace layers")
-    return permissions
+def _layer_status(config: dict[str, Any], key: str, default: bool) -> str:
+    return "enabled" if _enabled(config, key, default) else "disabled"
 
 
 def _placeholder_rule(config: dict[str, Any], prompt_relative: str) -> str:
@@ -192,53 +186,163 @@ def _placeholder_rule(config: dict[str, Any], prompt_relative: str) -> str:
     return f"- Preserve these literal template expressions in `{prompt_relative}`: {rendered}."
 
 
-def build_prompt(checkout: Path, ctx: OperatorContext) -> tuple[str, dict[str, Any]]:
+def _instructions(config: dict[str, Any], template_rule: str, *, trajectory_only: bool = False) -> str:
+    instructions = (
+        [
+            "Analyze the behavior-only trajectory summaries and proxy judge verdicts before editing; do not search "
+            "for evaluator labels or test feedback.",
+            "Sort tasks by proxy score, prioritize likely failures, and group recurring categories and failure "
+            "reasons. Make one coherent, transferable change only when supported by the behavioral evidence.",
+        ]
+        if trajectory_only
+        else [
+            "Review the trace-analyzer feedback and task summaries before editing; inspect the complete evidence files "
+            "when the inline view is truncated or a claim needs verification.",
+            "Make one coherent change anywhere inside the mutable surface when supported by the evidence.",
+        ]
+    )
+    if _enabled(config, "evolve_skills", True):
+        instructions.append("Review draft skills: refine into a real skill, merge with an existing skill, or discard.")
+        instructions.append("Update current skills only when supported by the observations.")
+    if _enabled(config, "evolve_prompts", True):
+        instructions.append("Update the runtime prompt only with concise, transferable instructions.")
+    if _enabled(config, "evolve_memory", True):
+        instructions.append("Add or prune long-term memory only when the lesson should apply across tasks.")
+    if _enabled(config, "evolve_tools", False):
+        instructions.append("Add or modify candidate-owned tools only when their runtime invocation is verified.")
+    instructions.extend(
+        [
+            "Do not add standalone files to a disabled context layer unless the same change wires them into runtime.",
+            "Inspect files with your filesystem tools before writing.",
+            "Verify changes with `git diff` and run proportionate checks.",
+        ]
+    )
+    if template_rule:
+        instructions.append(template_rule.removeprefix("- "))
+    return "\n".join(f"{index}. {instruction}" for index, instruction in enumerate(instructions, 1))
+
+
+def _selected_variant(ctx: OperatorContext) -> str:
+    for path in (
+        ctx.run_dir / "trace_analyzer" / "evidence" / "manifest.json",
+        ctx.run_dir / "feedback" / "evidence" / "manifest.json",
+    ):
+        payload = _read_json(path)
+        if isinstance(payload, dict) and payload.get("selected_variant"):
+            return str(payload["selected_variant"])
+    return ""
+
+
+def _selected_case_count(ctx: OperatorContext) -> int:
+    for path in (
+        ctx.run_dir / "trace_analyzer" / "evidence" / "manifest.json",
+        ctx.run_dir / "feedback" / "evidence" / "manifest.json",
+    ):
+        payload = _read_json(path)
+        if isinstance(payload, dict):
+            cases = payload.get("cases")
+            if isinstance(cases, int) and not isinstance(cases, bool) and cases >= 0:
+                return cases
+    return 0
+
+
+def _trajectory_only_evidence(observation: str, ctx: OperatorContext) -> str:
+    for path in (
+        ctx.run_dir / "feedback" / "evidence" / "selected.md",
+        ctx.run_dir / "trace_analyzer" / "evidence" / "selected.md",
+    ):
+        try:
+            selected = path.read_text().strip()
+        except OSError:
+            continue
+        if selected:
+            break
+    else:
+        selected = observation.strip() or "(No behavior-only trajectory evidence was produced.)"
+    limit = _positive_int(ctx.config.get("evidence_chars"), DEFAULT_INLINE_EVIDENCE_CHARS)
+    if len(selected) <= limit:
+        return selected
+    return selected[:limit] + f"\n...[behavior evidence truncated {len(selected) - limit} chars]..."
+
+
+def _evidence_section(observation: str, ctx: OperatorContext, *, trajectory_only: bool = False) -> str:
+    if trajectory_only:
+        return _trajectory_only_evidence(observation, ctx)
+    relative_run = Path("runs") / f"gen-{ctx.genid}"
+    feedback_root = relative_run / "feedback"
+    raw_root = relative_run / "trace_analyzer" / "evidence"
+    feedback = load_feedback(ctx.run_dir, fallback=observation).strip()
+    if not feedback:
+        feedback = "(No trace-analyzer feedback was produced for this generation.)"
+    limit = _positive_int(ctx.config.get("evidence_chars"), DEFAULT_INLINE_EVIDENCE_CHARS)
+    marker = f"\n\n[inline evidence truncated; inspect the complete feedback bundle at `{feedback_root.as_posix()}/`]"
+    if len(feedback) > limit:
+        feedback = feedback[: max(limit - len(marker), 0)] + marker
+    return (
+        "### Trace-Analyzer Feedback\n\n"
+        f"{feedback}\n\n"
+        f"- Complete feedback bundle: `{feedback_root.as_posix()}/`\n"
+        f"- Selected evidence: `{(feedback_root / 'evidence' / 'selected.md').as_posix()}`\n"
+        f"- Raw trace evidence: `{raw_root.as_posix()}/`"
+    )
+
+
+def build_prompt(
+    checkout: Path,
+    ctx: OperatorContext,
+    observation: str = "",
+) -> tuple[str, dict[str, Any]]:
     prompt_path, prompt_relative = _relative_path(checkout, ctx.config.get("prompt_path"), "target/prompts/system.md")
+    if not prompt_path.is_file():
+        raise ValueError(f"A-Evolve prompt_path must reference an existing file: {prompt_relative}")
     skills_dir, skills_relative = _relative_path(checkout, ctx.config.get("skills_dir"), "target/skills")
     _, memory_relative = _relative_path(checkout, ctx.config.get("memory_dir"), "target/memory")
     _, tools_relative = _relative_path(checkout, ctx.config.get("tools_dir"), "target/tools")
-    paths = {
-        "prompt": prompt_relative,
-        "skills": skills_relative,
-        "memory": memory_relative,
-        "tools": tools_relative,
-    }
-    summaries = _case_summaries(ctx)
+    trajectory_only = _selected_variant(ctx) == TRAJECTORY_ONLY_VARIANT
+    summaries = [] if trajectory_only else _case_summaries(ctx)
+    tasks_analyzed = _selected_case_count(ctx) if trajectory_only else len(summaries)
     drafts = _drafts(skills_dir)
     skill_names = _skills(skills_dir)
-    permissions = _permissions(ctx.config, paths)
     template_rule = _placeholder_rule(ctx.config, prompt_relative)
     prompt = (
         f"{AEVOLVE_SYSTEM_PROMPT.rstrip()}\n\n"
         f"## Evolution Cycle #{ctx.genid}\n\n"
         f"### Workspace Layout\n"
-        f"- System prompt: `{prompt_relative}`\n"
+        f"- Runtime prompt/config: `{prompt_relative}`\n"
         f"- Reusable skills: `{skills_relative}/*/SKILL.md`\n"
         f"- Draft skills: `{skills_relative}/_drafts/*.md`\n"
         f"- Memory: `{memory_relative}/`\n"
         f"- Tools: `{tools_relative}/`\n\n"
-        f"### Permissions\n{chr(10).join(permissions)}\n\n"
-        f"### Task Summaries (last {ctx.config.get('history_cycles', 2)} cycles, at most "
-        f"{ctx.config.get('max_observations', 30)})\n```json\n"
-        f"{json.dumps(summaries, indent=2, sort_keys=True)}\n```\n\n"
-        f"### Draft Skills\n{_draft_section(drafts)}\n\n"
+        f"{workspace_contract(checkout, ctx.config)}\n\n"
+        "### Managed Evolution Layers\n"
+        f"- Prompt evolution: {_layer_status(ctx.config, 'evolve_prompts', True)}\n"
+        f"- Skills evolution: {_layer_status(ctx.config, 'evolve_skills', True)}\n"
+        f"- Memory evolution: {_layer_status(ctx.config, 'evolve_memory', True)}\n"
+        f"- Tools evolution: {_layer_status(ctx.config, 'evolve_tools', False)}\n"
+        "These switches control which reusable context stores A-Evolve should manage; they are not filesystem permissions.\n\n"
+        + (
+            f"{_evidence_section(observation, ctx, trajectory_only=True)}\n\n"
+            if trajectory_only
+            else (
+                f"### Task Summaries (last {ctx.config.get('history_cycles', 2)} cycles, at most "
+                f"{ctx.config.get('max_observations', 30)})\n```json\n"
+                f"{json.dumps(summaries, indent=2, sort_keys=True)}\n```\n\n"
+                f"{_evidence_section(observation, ctx)}\n\n"
+            )
+        )
+        + f"### Draft Skills\n{_draft_section(drafts)}\n\n"
         f"### Current Skills ({len(skill_names)})\n"
         f"{chr(10).join(f'- {name}' for name in skill_names) if skill_names else 'No skills yet.'}\n\n"
-        "### Instructions\n"
-        "1. Review the task summaries and identify patterns, common failures, and recurring themes.\n"
-        "2. Review draft skills: refine into a real skill, merge with an existing skill, or discard.\n"
-        "3. Review current skills and update them only when supported by the observations.\n"
-        "4. Update enabled prompt or memory layers only with concise, transferable insights.\n"
-        "5. Inspect files with your filesystem tools before writing.\n"
-        "6. Verify changes with `git diff` and run proportionate checks.\n"
-        f"{template_rule}\n\n"
+        f"### Instructions\n{_instructions(ctx.config, template_rule, trajectory_only=trajectory_only)}\n\n"
         "Edit the candidate checkout directly. Do not merely print a patch. When done, summarize what you changed and why.\n"
     )
     return prompt, {
         "summaries": summaries,
+        "tasks_analyzed": tasks_analyzed,
         "drafts": drafts,
         "skills_before": skill_names,
         "skills_dir": skills_dir,
+        "trajectory_only": trajectory_only,
     }
 
 
@@ -252,11 +356,12 @@ def _clear_drafts(skills_dir: Path) -> None:
 
 class AEvolveMetaAgent(MetaAgentOperator):
     def run(self, checkout: Path, observation: str, ctx: OperatorContext) -> MetaAgentResult:
-        del observation
         parent_ref = patch_parent_ref(checkout, ctx)
         out = ctx.run_dir / "meta_agent"
         out.mkdir(parents=True, exist_ok=True)
-        prompt, state = build_prompt(checkout, ctx)
+        prompt, state = build_prompt(checkout, ctx, observation)
+        if state["trajectory_only"]:
+            ctx.config["trajectory_only"] = True
         (out / "prompt.md").write_text(prompt)
         try:
             agent_run = run_agent(checkout, prompt, ctx)
@@ -279,7 +384,7 @@ class AEvolveMetaAgent(MetaAgentOperator):
         usage = _safe_usage(agent_run.usage)
         report = {
             "evo_number": ctx.genid,
-            "tasks_analyzed": len(state["summaries"]),
+            "tasks_analyzed": state["tasks_analyzed"],
             "drafts_reviewed": len(state["drafts"]),
             "skills_before": len(skills_before),
             "skills_after": len(skills_after),

--- a/library/meta_agent/ahe.py
+++ b/library/meta_agent/ahe.py
@@ -12,6 +12,7 @@ from evolve.frozen import sdk
 from evolve.frozen.interfaces import MetaAgentOperator, MetaAgentResult, OperatorContext
 from evolve.patching import create_candidate_patch, load_surface_policy, patch_parent_ref
 from library.meta_agent.runners import run_agent, runner_name
+from library.meta_agent.support.workspace import workspace_contract
 
 MANIFEST_START = "<AHE_CHANGE_MANIFEST>"
 MANIFEST_END = "</AHE_CHANGE_MANIFEST>"
@@ -78,11 +79,6 @@ def _safe_usage(usage: object) -> dict[str, Any]:
     usd = normalized.get("usd", 0)
     normalized["usd"] = usd if isinstance(usd, (int, float)) and not isinstance(usd, bool) else 0
     return normalized
-
-
-def _surface_rules(checkout: Path) -> str:
-    surface = load_surface_policy(checkout)
-    return f"- Surface include: {surface.include}\n- Surface exclude: {surface.exclude}"
 
 
 def _required_text(path: Path, label: str) -> str:
@@ -191,7 +187,7 @@ def build_prompt(checkout: Path, observation: str, ctx: OperatorContext) -> str:
         f"Archive: {experiment / 'archive.jsonl'}\n"
         f"Current generation artifacts: {current_run}\n"
         f"Raw trace evidence: {current_run / 'trace_analyzer' / 'evidence'}\n\n"
-        f"# Surface Rules\n\n{_surface_rules(checkout)}\n\n"
+        f"{workspace_contract(checkout, ctx.config, action_paths=['target'])}\n\n"
         "# Required Final Output\n\nEdit the candidate directly. After checks and before the submission action, "
         f"write the following JSON object to `{MANIFEST_FILE}`. Write JSON only; this control file is removed "
         "before the candidate patch is created. Then submit normally.\n\n"

--- a/library/meta_agent/gepa.py
+++ b/library/meta_agent/gepa.py
@@ -18,15 +18,11 @@ from library.meta_agent.support.workspace import workspace_contract
 
 GEPA_PROMPT = """# GEPA Reflective Mutation
 
-Improve an agent component using the supplied execution examples. Each example
-contains the task input, the agent's generated messages and ordered tool
-trajectory, verifier feedback, and reward.
-
-Infer a concise, transferable lesson across examples, inspect the current
-component, and edit only the selected component paths. Preserve behavior that
-worked. Do not encode benchmark answers or change the evaluator, dataset,
-splits, Harbor adapter, mechanism, credentials, endpoint, model, or resource
-limits. Edit the checkout directly and run proportionate checks.
+Improve the live candidate using reflective feedback from its executions.
+Read the proposal inputs from the files listed below, inspect the candidate,
+and edit the checkout directly. Preserve behavior that worked. Do not encode
+benchmark answers or change the evaluator, dataset, splits, Harbor adapter,
+mechanism, credentials, endpoint, model, or resource limits.
 """
 
 
@@ -44,56 +40,45 @@ def _safe_usage(usage: object) -> dict[str, Any]:
     return normalized
 
 
-def _component_snapshot(checkout: Path, scopes: list[str], limit: int) -> str:
-    chunks: list[str] = []
-    remaining = limit
-    for scope in scopes:
-        root = checkout / scope
-        paths = (
-            [root]
-            if root.is_file()
-            else sorted(path for path in root.rglob("*") if path.is_file())
-            if root.is_dir()
-            else []
-        )
-        for path in paths:
-            if path.is_symlink():
-                continue
+def _agent_path(path: Path, ctx: OperatorContext) -> str:
+    if runner_name(ctx) == "harbor":
+        for root in (ctx.checkout, ctx.workspace):
             try:
-                text = path.read_text()
-            except (OSError, UnicodeDecodeError):
+                relative = path.relative_to(root).as_posix()
+            except ValueError:
                 continue
-            relative = path.relative_to(checkout).as_posix()
-            rendered = f"### `{relative}`\n\n```text\n{text}\n```\n"
-            chunks.append(rendered[:remaining])
-            remaining -= min(len(rendered), remaining)
-            if remaining <= 0:
-                return "\n".join(chunks) + "\n...[component snapshot truncated]...\n"
-    return "\n".join(chunks) or "(selected component does not currently exist)"
+            return f"/app/task/workspace/{relative}"
+        raise ValueError(f"GEPA agent input path is outside the candidate and workspace: {path}")
+    return str(path.resolve())
 
 
 def build_prompt(checkout: Path, ctx: OperatorContext) -> tuple[str, dict[str, Any]]:
     components = component_paths(ctx.config)
     selected = selected_component_names(ctx.config, ctx.genid)
-    dataset_path = ctx.run_dir / "trace_analyzer" / "evidence" / "reflective_dataset.json"
-    payload = read_json(dataset_path)
-    if not isinstance(payload, dict):
-        raise ValueError(f"missing GEPA reflective dataset: {dataset_path}")
-    selected_dataset = {name: payload.get(name, []) if isinstance(payload.get(name), list) else [] for name in selected}
-    max_examples = max(1, int(ctx.config.get("max_examples", 16)))
-    selected_dataset = {name: records[:max_examples] for name, records in selected_dataset.items()}
-    max_dataset_chars = max(1, int(ctx.config.get("dataset_chars", 60000)))
-    rendered_dataset = json.dumps(selected_dataset, indent=2, sort_keys=True)
-    if len(rendered_dataset) > max_dataset_chars:
-        rendered_dataset = rendered_dataset[:max_dataset_chars] + "\n...[reflective dataset truncated]..."
-    scopes = [path for name in selected for path in components[name]]
-    snapshot = _component_snapshot(checkout, scopes, max(1, int(ctx.config.get("component_chars", 30000))))
+    evidence_root = ctx.run_dir / "trace_analyzer" / "evidence"
+    manifest_path = evidence_root / "manifest.json"
+    manifest = read_json(manifest_path)
+    if not isinstance(manifest, dict) or not isinstance(manifest.get("component_evidence"), dict):
+        raise ValueError(f"missing GEPA component evidence manifest: {manifest_path}")
+    component_evidence = manifest["component_evidence"]
+    evidence_files: dict[str, str] = {}
+    example_counts: dict[str, int] = {}
+    for name in selected:
+        entry = component_evidence.get(name)
+        if not isinstance(entry, dict) or not isinstance(entry.get("file"), str):
+            raise ValueError(f"missing GEPA evidence for component {name!r}: {manifest_path}")
+        evidence_path = evidence_root / entry["file"]
+        if not evidence_path.is_file():
+            raise ValueError(f"missing GEPA component evidence: {evidence_path}")
+        evidence_files[name] = _agent_path(evidence_path, ctx)
+        example_counts[name] = int(entry.get("records") or 0)
+    focus_paths = [path for name in selected for path in components[name]]
     required_placeholders = ctx.config.get("required_placeholders") or []
     if not isinstance(required_placeholders, list) or not all(
         isinstance(value, str) and value for value in required_placeholders
     ):
         raise ValueError("required_placeholders must be a list of non-empty strings")
-    if path_in_scopes("target/prompt.md", scopes) and "{{ instruction }}" not in required_placeholders:
+    if path_in_scopes("target/prompt.md", focus_paths) and "{{ instruction }}" not in required_placeholders:
         required_placeholders.append("{{ instruction }}")
     placeholder_rule = (
         "Preserve these literal template expressions: "
@@ -102,26 +87,37 @@ def build_prompt(checkout: Path, ctx: OperatorContext) -> tuple[str, dict[str, A
         if required_placeholders
         else ""
     )
+    component_inputs = "\n".join(
+        f"- `{name}` evidence: `{evidence_files[name]}`\n"
+        f"  Candidate focus paths: {', '.join(f'`{path}`' for path in components[name])}"
+        for name in selected
+    )
     prompt = (
         f"{GEPA_PROMPT.rstrip()}\n\n"
-        f"{workspace_contract(checkout, ctx.config, action_paths=scopes)}\n\n"
-        f"## Selected component\n\n{', '.join(f'`{name}`' for name in selected)}\n\n"
-        f"Allowed paths: {', '.join(f'`{path}`' for path in scopes)}\n\n"
+        f"{workspace_contract(checkout, ctx.config)}\n\n"
+        "## Inputs\n\n"
+        "Read these files before deciding what to change:\n\n"
+        f"1. Evidence manifest: `{_agent_path(manifest_path, ctx)}`\n"
+        f"2. Selected component evidence:\n{component_inputs}\n"
+        f"3. Inspect the live candidate under `{_agent_path(checkout / 'target', ctx)}`. "
+        "Start with the candidate focus paths above, then inspect related target files when useful.\n\n"
         f"{placeholder_rule}\n\n"
-        f"## Current component\n\n{snapshot}\n\n"
-        f"## Reflective dataset\n\n```json\n{rendered_dataset}\n```\n\n"
         "## Required action\n\n"
         "1. Compare high- and low-reward trajectories and verifier feedback.\n"
-        "2. State a general lesson internally, then make one coherent component edit.\n"
-        "3. Do not edit paths outside the allowed paths.\n"
-        "4. Verify the diff and summarize the hypothesis and expected effect.\n"
+        "2. Infer a transferable lesson and make one coherent improvement to the live candidate.\n"
+        "3. You may modify any file allowed by the candidate workspace contract.\n"
+        "4. Run proportionate checks, verify the diff, and summarize the hypothesis and expected effect.\n"
     )
     proposal = {
         "parent": ctx.parent,
         "components": selected,
-        "paths": scopes,
-        "reflective_dataset": dataset_path.relative_to(ctx.workspace).as_posix(),
-        "example_counts": {name: len(records) for name, records in selected_dataset.items()},
+        "paths": focus_paths,
+        "evidence_manifest": manifest_path.relative_to(ctx.workspace).as_posix(),
+        "evidence_files": {
+            name: (evidence_root / component_evidence[name]["file"]).relative_to(ctx.workspace).as_posix()
+            for name in selected
+        },
+        "example_counts": example_counts,
     }
     return prompt, proposal
 
@@ -148,18 +144,16 @@ class GepaMetaAgent(MetaAgentOperator):
             surface=load_surface_policy(checkout),
             repair=False,
         )
-        scopes = list(proposal["paths"])
-        violations = [path for path in patch.changed_paths if not path_in_scopes(path, scopes)]
+        violations = list(patch.surface_report.get("violations") or [])
         usage = _safe_usage(agent_run.usage)
         (out / "model_patch.diff").write_text(patch.diff)
         (out / "patch.diff").write_text(patch.diff)
         (out / "output.txt").write_text(agent_run.output)
         _write_json(out / "changed.json", patch.changed_paths)
         _write_json(out / "surface-check.json", patch.surface_report)
-        _write_json(out / "component-scope-check.json", {"ok": not violations, "violations": violations})
         _write_json(out / "usage.json", usage)
         if violations:
-            raise SystemExit("GEPA meta-agent changed paths outside the selected component: " + ", ".join(violations))
+            raise SystemExit("GEPA meta-agent changed paths outside the mutable surface: " + ", ".join(violations))
         notes = [
             "variant: gepa",
             f"runner: {runner_name(ctx)}",

--- a/library/meta_agent/gepa.py
+++ b/library/meta_agent/gepa.py
@@ -14,6 +14,7 @@ from evolve.frozen.interfaces import MetaAgentOperator, MetaAgentResult, Operato
 from evolve.patching import create_candidate_patch, load_surface_policy, patch_parent_ref
 from library.gepa_support import component_paths, path_in_scopes, read_json, selected_component_names
 from library.meta_agent.runners import run_agent, runner_name
+from library.meta_agent.support.workspace import workspace_contract
 
 GEPA_PROMPT = """# GEPA Reflective Mutation
 
@@ -103,6 +104,7 @@ def build_prompt(checkout: Path, ctx: OperatorContext) -> tuple[str, dict[str, A
     )
     prompt = (
         f"{GEPA_PROMPT.rstrip()}\n\n"
+        f"{workspace_contract(checkout, ctx.config, action_paths=scopes)}\n\n"
         f"## Selected component\n\n{', '.join(f'`{name}`' for name in selected)}\n\n"
         f"Allowed paths: {', '.join(f'`{path}`' for path in scopes)}\n\n"
         f"{placeholder_rule}\n\n"

--- a/library/meta_agent/hyperagents.py
+++ b/library/meta_agent/hyperagents.py
@@ -11,6 +11,7 @@ from evolve.frozen import sdk
 from evolve.frozen.interfaces import MetaAgentOperator, MetaAgentResult
 from evolve.patching import create_candidate_patch, load_surface_policy, patch_parent_ref
 from library.meta_agent.runners import run_agent, runner_name
+from library.meta_agent.support.workspace import workspace_contract
 
 MAX_INLINE_EVIDENCE_CHARS = 50_000
 LATEST_DIFF_CHARS = 5_000
@@ -114,6 +115,7 @@ def build_prompt(checkout: Path, observation: str, ctx) -> str:
         experiment = ctx.workspace
     return (
         f"{PROMPT.rstrip()}\n\n"
+        f"{workspace_contract(checkout, ctx.config)}\n\n"
         f"{_prompt_evidence(observation, ctx)}\n\n"
         f"Repository: {repository}\n"
         f"Feedback bundle: {current_run / 'feedback'}\n"

--- a/library/meta_agent/runners/harbor.py
+++ b/library/meta_agent/runners/harbor.py
@@ -30,6 +30,8 @@ _READONLY_REPORT = "ahe-debugger-response.md"
 _EVAL_RECEIPT = ".evolve-eval-receipts.jsonl"
 _FILE_TASK_AGENT = "evolve_harbor_agent:FileTaskMiniSweAgent"
 _SAFE_INLINE_INSTRUCTION_BYTES = 96 * 1024
+_VISIBLE_RUN_INPUTS = ("rollout", "trace_analyzer", "feedback")
+_HIDDEN_WORKSPACE_ROOTS = {".git", "runs", "archive.jsonl", _EVAL_RECEIPT, "evaluator"}
 _SECRET_ASSIGNMENT = re.compile(
     r"(?i)\b([a-z0-9_-]*(?:api[_-]?key|access[_-]?token|auth(?:orization)?|secret|password))\b"
     r"([\"']?)(\s*[:=]\s*)([^\s,;}]+)"
@@ -160,11 +162,119 @@ def _tree_manifest(root: Path) -> dict[str, tuple[str, str]]:
     return manifest
 
 
+def _initialize_sanitized_git(workspace: Path) -> None:
+    git(workspace, "init", "--quiet")
+    git(workspace, "config", "user.name", "Evolve Meta-Agent")
+    git(workspace, "config", "user.email", "meta-agent@evolve.invalid")
+    git(workspace, "add", "--all")
+    git(workspace, "commit", "--quiet", "--no-gpg-sign", "-m", "sanitized meta-agent baseline")
+
+
+def _copy_visible_generation_inputs(source: Path, destination: Path) -> None:
+    for name in _VISIBLE_RUN_INPUTS:
+        subtree = source / name
+        if subtree.exists():
+            _copy_tree(subtree, destination / name)
+
+
+def _copy_visible_run_inputs(ctx: OperatorContext, workspace: Path) -> None:
+    runs = ctx.workspace / "runs"
+    if runs.is_dir():
+        for generation in sorted(runs.glob("gen-*")):
+            if generation.is_dir() and not generation.is_symlink():
+                _copy_visible_generation_inputs(
+                    generation,
+                    workspace / "runs" / generation.name,
+                )
+    _copy_visible_generation_inputs(
+        ctx.run_dir,
+        workspace / "runs" / f"gen-{ctx.genid}",
+    )
+
+
+def _private_task_names(workspace: Path) -> tuple[str, ...]:
+    path = workspace / "evaluator" / "splits.json"
+    try:
+        payload = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return ()
+    tasks = payload.get("tasks") if isinstance(payload, dict) else None
+    if not isinstance(tasks, dict):
+        return ()
+    names: set[str] = set()
+    for split in ("gate", "sealed"):
+        values = tasks.get(split)
+        if isinstance(values, list):
+            names.update(name for name in values if isinstance(name, str) and name)
+    return tuple(sorted(names))
+
+
+def _contains_private_task_name(path: Path, encoded_names: tuple[bytes, ...]) -> bool:
+    overlap = max((len(name) for name in encoded_names), default=1) - 1
+    tail = b""
+    try:
+        with path.open("rb") as stream:
+            while chunk := stream.read(1024 * 1024):
+                content = tail + chunk
+                if any(name in content for name in encoded_names):
+                    return True
+                tail = content[-overlap:] if overlap else b""
+    except OSError:
+        return False
+    return False
+
+
+def _assert_private_tasks_absent(workspace: Path, prompt: str, private_names: tuple[str, ...]) -> None:
+    if not private_names:
+        return
+    if any(name in prompt for name in private_names):
+        raise RuntimeError("Harbor meta-agent prompt contains a private gate/sealed task identifier")
+    encoded_names = tuple(name.encode() for name in private_names)
+    for path in workspace.rglob("*"):
+        if not path.is_file() or ".git" in path.relative_to(workspace).parts:
+            continue
+        if _contains_private_task_name(path, encoded_names):
+            raise RuntimeError("Harbor meta-agent workspace contains a private gate/sealed task identifier")
+
+
+def _expose_gate_data(config: dict[str, Any]) -> bool:
+    value = config.get("expose_gate_data", False)
+    if not isinstance(value, bool):
+        raise ValueError("expose_gate_data must be true or false")
+    return value
+
+
+def _copy_full_workspace_inputs(checkout: Path, ctx: OperatorContext, workspace: Path) -> None:
+    for path in workspace.iterdir():
+        if path.name != ".git":
+            _remove(path)
+    for source in checkout.iterdir():
+        if source.name not in {".git", "runs", "archive.jsonl", _EVAL_RECEIPT}:
+            _copy_tree(source, workspace / source.name)
+    archive = ctx.workspace / "archive.jsonl"
+    if archive.is_file():
+        _copy_tree(archive, workspace / "archive.jsonl")
+    receipt = ctx.workspace / _EVAL_RECEIPT
+    if receipt.is_file():
+        _copy_tree(receipt, workspace / _EVAL_RECEIPT)
+    runs = ctx.workspace / "runs"
+    if runs.is_dir():
+        _copy_tree(runs, workspace / "runs", ignore=_runs_ignore(runs))
+    if ctx.run_dir.is_dir():
+        _copy_tree(
+            ctx.run_dir,
+            workspace / "runs" / f"gen-{ctx.genid}",
+            ignore=_runs_ignore(ctx.run_dir.parent),
+        )
+
+
 def _prepare_bundle(
     checkout: Path,
     ctx: OperatorContext,
     value: object,
     surface: SurfacePolicy,
+    *,
+    prompt: str = "",
 ) -> _WorkspaceBundle:
     roots = _editable_roots(value, surface)
     for root in roots:
@@ -174,35 +284,18 @@ def _prepare_bundle(
     workspace = task_root / "workspace"
     try:
         task_root.mkdir(parents=True)
-        git(checkout, "clone", "--quiet", "--no-hardlinks", str(checkout), str(workspace))
-        git(workspace, "checkout", "--quiet", "--detach", head_commit(checkout))
-
-        for path in workspace.iterdir():
-            if path.name != ".git":
-                _remove(path)
-        for source in checkout.iterdir():
-            if source.name not in {".git", "runs", "archive.jsonl", _EVAL_RECEIPT}:
-                _copy_tree(source, workspace / source.name)
-
-        # A-Evolve trajectory-only mode must not expose evaluator labels through
-        # filesystem discovery. The selected behavior summaries are already
-        # transported in the meta-agent prompt, so omit archive/run artifacts.
-        if not bool(ctx.config.get("trajectory_only", False)):
-            archive = ctx.workspace / "archive.jsonl"
-            if archive.is_file():
-                _copy_tree(archive, workspace / "archive.jsonl")
-            receipt = ctx.workspace / _EVAL_RECEIPT
-            if receipt.is_file():
-                _copy_tree(receipt, workspace / _EVAL_RECEIPT)
-            runs = ctx.workspace / "runs"
-            if runs.is_dir():
-                _copy_tree(runs, workspace / "runs", ignore=_runs_ignore(runs))
-            if ctx.run_dir.is_dir():
-                _copy_tree(
-                    ctx.run_dir,
-                    workspace / "runs" / f"gen-{ctx.genid}",
-                    ignore=_runs_ignore(ctx.run_dir.parent),
-                )
+        if _expose_gate_data(ctx.config):
+            git(checkout, "clone", "--quiet", "--no-hardlinks", str(checkout), str(workspace))
+            git(workspace, "checkout", "--quiet", "--detach", head_commit(checkout))
+            _copy_full_workspace_inputs(checkout, ctx, workspace)
+        else:
+            workspace.mkdir()
+            for source in checkout.iterdir():
+                if source.name not in _HIDDEN_WORKSPACE_ROOTS:
+                    _copy_tree(source, workspace / source.name)
+            _copy_visible_run_inputs(ctx, workspace)
+            _assert_private_tasks_absent(workspace, prompt, _private_task_names(ctx.workspace))
+            _initialize_sanitized_git(workspace)
         return _WorkspaceBundle(staging, task_root, workspace, roots, _tree_manifest(workspace))
     except Exception:
         shutil.rmtree(staging, ignore_errors=True)
@@ -801,16 +894,30 @@ def run_agent(checkout: Path, prompt: str, ctx: OperatorContext) -> AgentRunResu
             raise ValueError(
                 "agent_pythonpath was removed; add the adapter to the workspace pyproject.toml and uv.lock"
             )
-        bundle = _prepare_bundle(checkout, ctx, ctx.config.get("editable_roots", ["target"]), surface)
+        bundle = _prepare_bundle(
+            checkout,
+            ctx,
+            ctx.config.get("editable_roots", ["target"]),
+            surface,
+            prompt=prompt,
+        )
         if (jobs_root / job_name).exists():
             raise RuntimeError(f"Harbor meta-agent job already exists: {jobs_root / job_name}")
         harbor, harbor_env = uv_run(ctx.workspace, "harbor")
         prompt_path.parent.mkdir(parents=True, exist_ok=True)
+        evidence_contract = (
+            "It contains the selected parent, full Git history, configuration, archive, evaluator, and complete "
+            "run evidence, including gate/sealed data."
+            if _expose_gate_data(ctx.config)
+            else "It contains the selected parent, a clean Git baseline, configuration, and current/prior "
+            "generations' train rollout, trace-analysis, and feedback evidence. Evaluator files, task partitions, "
+            "archive records, selection artifacts, and gate/sealed evaluations are intentionally unavailable."
+        )
         prompt_path.write_text(
             prompt.rstrip() + "\n\n# Harbor Runner Contract\n\n"
-            f"The disposable experiment workspace is at `{_ARTIFACT_SOURCE}`. It contains the selected parent, "
-            "Git history, configuration, archive, and run evidence. Work in that directory normally. Edit "
-            "only paths allowed by the supplied surface rules. Runtime evidence edits are discarded; only "
+            f"The disposable experiment workspace is at `{_ARTIFACT_SOURCE}`. {evidence_contract} "
+            "Work in that directory normally. "
+            "Edit only paths allowed by the supplied surface rules. Runtime evidence edits are discarded; only "
             "configured editable roots are imported after the complete workspace artifact passes the surface gate. "
             "Before finishing, remove generated virtual environments and caches inside editable roots (for example "
             "target/.venv, __pycache__, and .pytest_cache); returned editable roots must contain no symlinks.\n"

--- a/library/meta_agent/runners/harbor.py
+++ b/library/meta_agent/runners/harbor.py
@@ -184,21 +184,25 @@ def _prepare_bundle(
             if source.name not in {".git", "runs", "archive.jsonl", _EVAL_RECEIPT}:
                 _copy_tree(source, workspace / source.name)
 
-        archive = ctx.workspace / "archive.jsonl"
-        if archive.is_file():
-            _copy_tree(archive, workspace / "archive.jsonl")
-        receipt = ctx.workspace / _EVAL_RECEIPT
-        if receipt.is_file():
-            _copy_tree(receipt, workspace / _EVAL_RECEIPT)
-        runs = ctx.workspace / "runs"
-        if runs.is_dir():
-            _copy_tree(runs, workspace / "runs", ignore=_runs_ignore(runs))
-        if ctx.run_dir.is_dir():
-            _copy_tree(
-                ctx.run_dir,
-                workspace / "runs" / f"gen-{ctx.genid}",
-                ignore=_runs_ignore(ctx.run_dir.parent),
-            )
+        # A-Evolve trajectory-only mode must not expose evaluator labels through
+        # filesystem discovery. The selected behavior summaries are already
+        # transported in the meta-agent prompt, so omit archive/run artifacts.
+        if not bool(ctx.config.get("trajectory_only", False)):
+            archive = ctx.workspace / "archive.jsonl"
+            if archive.is_file():
+                _copy_tree(archive, workspace / "archive.jsonl")
+            receipt = ctx.workspace / _EVAL_RECEIPT
+            if receipt.is_file():
+                _copy_tree(receipt, workspace / _EVAL_RECEIPT)
+            runs = ctx.workspace / "runs"
+            if runs.is_dir():
+                _copy_tree(runs, workspace / "runs", ignore=_runs_ignore(runs))
+            if ctx.run_dir.is_dir():
+                _copy_tree(
+                    ctx.run_dir,
+                    workspace / "runs" / f"gen-{ctx.genid}",
+                    ignore=_runs_ignore(ctx.run_dir.parent),
+                )
         return _WorkspaceBundle(staging, task_root, workspace, roots, _tree_manifest(workspace))
     except Exception:
         shutil.rmtree(staging, ignore_errors=True)

--- a/library/meta_agent/support/workspace.py
+++ b/library/meta_agent/support/workspace.py
@@ -1,0 +1,106 @@
+"""Render one truthful candidate-workspace contract for meta-agent prompts."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from evolve.patching import load_surface_policy
+
+
+def _relative(value: object) -> str | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    path = Path(value.strip())
+    if path.is_absolute() or ".." in path.parts:
+        raise ValueError(f"meta-agent context path must be checkout-relative: {path}")
+    return path.as_posix()
+
+
+def _detected_prompt(checkout: Path, config: dict[str, Any]) -> str | None:
+    configured = _relative(config.get("prompt_path"))
+    if configured is not None:
+        return configured
+    components = config.get("components")
+    if isinstance(components, dict):
+        for name in ("system_prompt", "prompt"):
+            candidate = _relative(components.get(name))
+            if candidate is not None:
+                return candidate
+    for candidate in (
+        "target/prompt.md",
+        "target/src/minisweagent/config/mini.yaml",
+        "target/prompts/system.md",
+    ):
+        if (checkout / candidate).is_file():
+            return candidate
+    return None
+
+
+def _detected_directory(checkout: Path, config: dict[str, Any], key: str, default: str) -> str | None:
+    configured = _relative(config.get(key))
+    if configured is not None:
+        return configured
+    return default if (checkout / default).is_dir() else None
+
+
+def _editable_roots(config: dict[str, Any], includes: list[str]) -> list[str]:
+    configured = config.get("editable_roots")
+    if configured is not None:
+        if not isinstance(configured, list) or not all(
+            isinstance(item, str) and item and Path(item).name == item for item in configured
+        ):
+            raise ValueError("editable_roots must contain top-level relative directory names")
+        return list(dict.fromkeys(configured))
+    roots: list[str] = []
+    for pattern in includes:
+        root = pattern.split("/", 1)[0]
+        if root and not any(char in root for char in "*?[") and root not in roots:
+            roots.append(root)
+    return roots or ["target"]
+
+
+def _location(label: str, path: str | None) -> str:
+    return f"- {label}: `{path}`" if path is not None else f"- {label}: not configured or detected"
+
+
+def workspace_contract(
+    checkout: Path,
+    config: dict[str, Any],
+    *,
+    action_paths: list[str] | None = None,
+) -> str:
+    """Describe mutation permission separately from candidate runtime context paths."""
+    surface = load_surface_policy(checkout)
+    includes = list(surface.include)
+    excludes = list(surface.exclude)
+    roots = _editable_roots(config, includes)
+    prompt = _detected_prompt(checkout, config)
+    skills = _detected_directory(checkout, config, "skills_dir", "target/skills")
+    memory = _detected_directory(checkout, config, "memory_dir", "target/memory")
+    tools = _detected_directory(checkout, config, "tools_dir", "target/tools")
+    permissions = "\n".join(f"- You CAN modify any file under `{root}/`." for root in roots)
+    scope = (
+        "- This method further restricts the current proposal to: "
+        + ", ".join(f"`{path}`" for path in action_paths)
+        + "."
+        if action_paths
+        else "- This method does not impose a narrower per-proposal path scope."
+    )
+    return (
+        "# Candidate Workspace Contract\n\n"
+        "## Mutation Permission\n\n"
+        f"{permissions}\n"
+        f"- Enforced surface include: {includes}\n"
+        f"- Enforced surface exclude: {excludes}\n"
+        f"{scope}\n\n"
+        "`prompt_path`, `skills_dir`, `memory_dir`, and `tools_dir` identify runtime components; "
+        "they do not narrow the mutation permission above.\n\n"
+        "## Runtime Context Locations\n\n"
+        f"{_location('Runtime prompt/config', prompt)}\n"
+        f"{_location('Reusable skills', skills)}\n"
+        f"{_location('Long-term memory', memory)}\n"
+        f"{_location('Candidate-owned tools', tools)}\n\n"
+        "A file in a skills, memory, or tools directory affects the deployed agent only if the candidate runtime "
+        "loads or invokes it. When proposing such a file, verify or implement that runtime path in the same candidate."
+    )

--- a/library/rollout/harbor.py
+++ b/library/rollout/harbor.py
@@ -22,6 +22,7 @@ from evolve.host_runtime import uv_run
 from evolve.splits import harbor_task_pattern, load_manifest, select_dataset_tasks
 
 _INFRA_EXCEPTION_MARKERS = (
+    "infrastructure",
     "verifier",
     "environment",
     "docker",
@@ -152,6 +153,7 @@ def _codex_session_details(trial_dir: Path, field_limit: int) -> dict[str, Any]:
     tool_calls: list[dict[str, str]] = []
     observations: list[str] = []
     events: list[dict[str, Any]] = []
+    trajectory_events: list[dict[str, Any]] = []
     sessions = trial_dir / "agent" / "sessions"
     paths = sorted(sessions.rglob("*.jsonl")) if sessions.exists() else []
     for path in paths:
@@ -187,6 +189,7 @@ def _codex_session_details(trial_dir: Path, field_limit: int) -> dict[str, Any]:
                             "message": clipped,
                         }
                     )
+                    trajectory_events.append(events[-1])
             elif outer_type == "event_msg" and event_type == "agent_message":
                 message = payload.get("message")
                 if isinstance(message, str) and message.strip():
@@ -201,6 +204,7 @@ def _codex_session_details(trial_dir: Path, field_limit: int) -> dict[str, Any]:
                             "message": clipped,
                         }
                     )
+                    trajectory_events.append(events[-1])
             elif outer_type == "response_item" and event_type in {"function_call", "custom_tool_call"}:
                 call = {
                     "name": str(payload.get("name") or "unknown"),
@@ -216,11 +220,14 @@ def _codex_session_details(trial_dir: Path, field_limit: int) -> dict[str, Any]:
                         **call,
                     }
                 )
+                trajectory_events.append(events[-1])
             elif outer_type == "response_item" and event_type in {
                 "function_call_output",
                 "custom_tool_call_output",
             }:
-                output = _clip(payload.get("output") or "", field_limit, tail=True)
+                raw_output = payload.get("output") or ""
+                output = _clip(raw_output, field_limit, tail=True)
+                trajectory_output = _clip(raw_output, field_limit)
                 observations.append(output)
                 events.append(
                     {
@@ -231,12 +238,14 @@ def _codex_session_details(trial_dir: Path, field_limit: int) -> dict[str, Any]:
                         "observation": output,
                     }
                 )
+                trajectory_events.append({**events[-1], "observation": trajectory_output})
     return {
         "instruction": instructions[-1] if instructions else "",
         "agent_messages": messages[-4:],
         "tool_calls": tool_calls[-8:],
         "observations": observations[-8:],
         "events": events[-_TRACE_EVENT_LIMIT:],
+        "trajectory_events": trajectory_events,
         "raw_agent_output": "",
     }
 
@@ -252,6 +261,7 @@ def _trajectory_details(trial_dir: Path, field_limit: int) -> dict[str, Any]:
     tool_calls: list[dict[str, str]] = []
     observations: list[str] = []
     events: list[dict[str, Any]] = []
+    trajectory_events: list[dict[str, Any]] = []
     for step_index, step in enumerate(steps):
         if not isinstance(step, dict):
             continue
@@ -275,14 +285,17 @@ def _trajectory_details(trial_dir: Path, field_limit: int) -> dict[str, Any]:
                 tool_calls.append(normalized_call)
                 step_calls.append(normalized_call)
         step_observations: list[str] = []
+        trajectory_observations: list[str] = []
         observation = step.get("observation")
         results = observation.get("results") if isinstance(observation, dict) else None
         if isinstance(results, list):
             for result in results:
                 if isinstance(result, dict) and result.get("content"):
-                    content = _clip(result["content"], field_limit, tail=True)
+                    raw_content = result["content"]
+                    content = _clip(raw_content, field_limit, tail=True)
                     observations.append(content)
                     step_observations.append(content)
+                    trajectory_observations.append(_clip(raw_content, field_limit))
         if not wrapper_message and (message or step_calls or step_observations):
             events.append(
                 {
@@ -291,6 +304,12 @@ def _trajectory_details(trial_dir: Path, field_limit: int) -> dict[str, Any]:
                     "message": _clip(message or "", field_limit),
                     "tool_calls": step_calls,
                     "observations": step_observations,
+                }
+            )
+            trajectory_events.append(
+                {
+                    **events[-1],
+                    "observations": trajectory_observations,
                 }
             )
 
@@ -309,6 +328,7 @@ def _trajectory_details(trial_dir: Path, field_limit: int) -> dict[str, Any]:
         "tool_calls": tool_calls[-8:],
         "observations": observations[-8:],
         "events": events[-_TRACE_EVENT_LIMIT:],
+        "trajectory_events": trajectory_events,
         "raw_agent_output": raw_agent_output,
     }
 
@@ -370,6 +390,7 @@ def collect_cases(jobs_dir: Path, field_limit: int = 2000, pass_threshold: float
                 "tool_calls": details["tool_calls"],
                 "observations": details["observations"],
                 "events": details["events"],
+                "trajectory_events": details["trajectory_events"],
                 "raw_agent_output": details["raw_agent_output"],
                 "verifier_output": _verifier_output(trial_dir, field_limit),
                 "verifier_rewards": {
@@ -396,6 +417,16 @@ def collect_cases(jobs_dir: Path, field_limit: int = 2000, pass_threshold: float
             }
         )
     return cases
+
+
+def require_usable_cases(cases: list[dict[str, Any]], *, returncode: int, harbor_log: Path) -> None:
+    if not cases:
+        raise SystemExit(f"harbor rollout produced no trial results (exit {returncode}); see {harbor_log}")
+    if all(case.get("outcome") in {"infra_error", "incomplete"} for case in cases):
+        raise SystemExit(
+            "harbor rollout produced only infrastructure failures; refusing to evolve the target from invalid "
+            f"evidence (exit {returncode}); see {harbor_log}"
+        )
 
 
 def _jobs_root(ctx: OperatorContext) -> Path:
@@ -518,13 +549,23 @@ def _select_train_tasks(
         or not all(isinstance(item, str) and item for item in requested)
     ):
         raise ValueError("task_names must be a non-empty list of task names")
-    if len(set(requested)) != len(requested):
-        raise ValueError("task_names must not contain duplicates")
     train_set = set(all_train)
-    unknown = [name for name in requested if name not in train_set]
+    normalized: list[str] = []
+    unknown: list[str] = []
+    for name in requested:
+        if name in train_set:
+            normalized.append(name)
+            continue
+        leaf = name.rsplit("/", 1)[-1] if "/" in name else ""
+        if leaf in train_set:
+            normalized.append(leaf)
+        else:
+            unknown.append(name)
     if unknown:
         raise ValueError("task_names must come from the frozen train split: " + ", ".join(unknown))
-    return list(requested)
+    if len(set(normalized)) != len(normalized):
+        raise ValueError("task_names must not contain duplicates")
+    return normalized
 
 
 class HarborRollout(RolloutOperator):
@@ -635,7 +676,7 @@ class HarborRollout(RolloutOperator):
             {
                 "type": "bind",
                 "source": str(uv_cache.resolve()),
-                "target": "/installed-agent/uv-cache",
+                "target": "/opt/evolve/uv/cache",
             }
         ]
         uv_python = os.environ.get("EVOLVE_UV_PYTHON_INSTALL_DIR")
@@ -656,6 +697,7 @@ class HarborRollout(RolloutOperator):
             ]
         )
         _append_agent_env(command, checkout, ctx.config)
+        command.extend(["--ae", "UV_CACHE_DIR=/opt/evolve/uv/cache"])
         if uv_python:
             command.extend(["--ae", "UV_PYTHON_INSTALL_DIR=/installed-agent/uv-python"])
         model = ctx.config.get("model") or eval_env.get("EVOLVE_HARBOR_MODEL") or os.environ.get("EVOLVE_HARBOR_MODEL")
@@ -674,10 +716,7 @@ class HarborRollout(RolloutOperator):
         returncode = _run_harbor(command, checkout, rollout_dir / "harbor.log", harbor_env)
         cases = collect_cases(jobs_dir, field_limit=field_limit, pass_threshold=pass_threshold)
         _write_json(rollout_dir / "cases.json", cases)
-        if not cases:
-            raise SystemExit(
-                f"harbor rollout produced no trial results (exit {returncode}); see {rollout_dir / 'harbor.log'}"
-            )
+        require_usable_cases(cases, returncode=returncode, harbor_log=rollout_dir / "harbor.log")
 
         rewards = [case["reward"] for case in cases if isinstance(case.get("reward"), (int, float))]
         counts = {name: sum(case["outcome"] == name for case in cases) for name in _OUTCOME_ORDER}

--- a/library/trace_analyzer/gepa.py
+++ b/library/trace_analyzer/gepa.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import json
+import re
 from collections import Counter
 from pathlib import Path
 from typing import Any
@@ -29,6 +30,11 @@ def _clip(value: object, limit: int) -> object:
     return value
 
 
+def _component_filename(index: int, name: str) -> str:
+    stem = re.sub(r"[^A-Za-z0-9_.-]", "_", name).strip("._-") or "component"
+    return f"{index:02d}-{stem}.json"
+
+
 def reflective_record(case: dict[str, Any], field_limit: int) -> dict[str, Any]:
     reward = case.get("reward")
     score = float(reward) if isinstance(reward, (int, float)) and not isinstance(reward, bool) else 0.0
@@ -39,7 +45,7 @@ def reflective_record(case: dict[str, Any], field_limit: int) -> dict[str, Any]:
         },
         "Generated Outputs": {
             "agent_messages": _clip(case.get("agent_messages") or [], field_limit),
-            "ordered_events": _clip(case.get("events") or [], field_limit),
+            "ordered_events": _clip(case.get("trajectory_events") or case.get("events") or [], field_limit),
             "tool_calls": _clip(case.get("tool_calls") or [], field_limit),
             "tool_results": _clip(case.get("observations") or [], field_limit),
             "raw_agent_output": _clip(case.get("raw_agent_output") or "", field_limit),
@@ -68,6 +74,17 @@ class GepaTraceAnalyzer(TraceAnalyzerOperator):
         root = ctx.run_dir / "trace_analyzer" / "evidence"
         _write_json(root / "reflective_dataset.json", dataset)
         _write_json(root / "raw_traces.json", usable)
+        component_evidence: dict[str, dict[str, Any]] = {}
+        component_artifacts: list[str] = []
+        for index, (name, paths) in enumerate(components.items()):
+            relative = Path("reflection") / _component_filename(index, name)
+            _write_json(root / relative, records)
+            component_evidence[name] = {
+                "paths": paths,
+                "records": len(records),
+                "file": relative.as_posix(),
+            }
+            component_artifacts.append(f"trace_analyzer/evidence/{relative.as_posix()}")
         outcomes = Counter(str(case.get("outcome") or "unknown") for case in cases)
         metrics = {
             "trials": len(cases),
@@ -88,6 +105,7 @@ class GepaTraceAnalyzer(TraceAnalyzerOperator):
             "selected_variant": "gepa",
             "source": "rollout/cases.json",
             "components": components,
+            "component_evidence": component_evidence,
             "reflective_dataset": "reflective_dataset.json",
             "excluded_outcomes": ["infra_error", "incomplete"],
         }
@@ -114,6 +132,7 @@ class GepaTraceAnalyzer(TraceAnalyzerOperator):
             "trace_analyzer/evidence/raw_traces.json",
             "trace_analyzer/evidence/metrics.json",
             "trace_analyzer/evidence/selected.md",
+            *component_artifacts,
         ]
         return TraceAnalyzerResult(
             summary={

--- a/library/trace_analyzer/trajectory_only.py
+++ b/library/trace_analyzer/trajectory_only.py
@@ -1,0 +1,196 @@
+"""Run the official-style behavior-only trajectory judge for A-Evolve."""
+
+from __future__ import annotations
+
+import concurrent.futures
+import hashlib
+import json
+import re
+from dataclasses import replace
+from pathlib import Path
+from typing import Any
+
+from evolve.agent import AgentCommandError
+from evolve.config import operator_blocks
+from evolve.frozen import sdk
+from evolve.frozen.interfaces import OperatorContext, TraceAnalyzerOperator, TraceAnalyzerResult
+from evolve.trace_analysis import (
+    _load_cases,
+    _positive_int,
+    _trajectory_only_cases,
+    trajectory_signal_records,
+    write_evidence_bundle,
+)
+from library.meta_agent.runners import run_readonly_agent
+
+Case = dict[str, Any]
+
+JUDGE_SYSTEM_PROMPT = """You are evaluating whether an AI agent successfully completed a command-line task.
+You can ONLY see the agent's actions (commands run and their outputs). You do NOT have access to actual test
+results. Based on the trajectory, estimate whether the task was completed successfully."""
+
+JUDGE_USER_TEMPLATE = """Task: {task_id}
+
+Agent trajectory:
+{trajectory}
+
+Evaluate the agent from this behavior alone:
+1. Score from 0 to 10 (0 complete failure, 5 partial progress, 10 likely fully solved).
+2. Category (for example build, debug, data-science, security, scientific, system-admin, software-engineering).
+3. One-sentence outcome.
+4. A concrete failure reason when score is below 7.
+
+Return only this JSON object:
+{{"score": N, "category": "...", "outcome": "...", "failure_reason": "..."}}"""
+
+_RUNNER_KEYS = (
+    "agent",
+    "model",
+    "environment",
+    "image",
+    "agent_kwargs",
+    "agent_env",
+    "agent_pythonpath",
+)
+
+
+def _runner_config(checkout: Path) -> dict[str, Any]:
+    meta = operator_blocks(checkout).get("meta_agent")
+    if not isinstance(meta, dict):
+        raise RuntimeError("trajectory_only judge requires operators.meta_agent configuration")
+    config = {key: meta[key] for key in _RUNNER_KEYS if key in meta}
+    config["max_retries"] = 0
+    if not config.get("agent") or not config.get("model"):
+        raise RuntimeError("trajectory_only judge requires meta-agent agent and model")
+    return config
+
+
+def _safe_slug(value: str) -> str:
+    if re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]{0,199}", value):
+        return value
+    return "task-" + hashlib.sha256(value.encode()).hexdigest()
+
+
+def _runner_prompt(record: Case, config: dict[str, Any]) -> str:
+    prompt = (
+        JUDGE_SYSTEM_PROMPT
+        + "\n\n"
+        + JUDGE_USER_TEMPLATE.format(
+            task_id=record.get("task_id") or "unknown",
+            trajectory=record.get("compressed_trajectory") or "",
+        )
+    )
+    agent = str(config.get("agent") or "")
+    if agent != "mini-swe-agent" and not agent.endswith(":FileTaskMiniSweAgent"):
+        return prompt
+    return (
+        prompt + "\n\nUse Bash only to write the JSON object to "
+        "`/logs/artifacts/ahe-debugger-response.md`, then run "
+        "`echo COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT`. Do not inspect or modify the experiment workspace."
+    )
+
+
+def _json_object(text: str) -> Case:
+    stripped = text.strip()
+    if "```" in stripped:
+        blocks = stripped.split("```")
+        candidates = [block.removeprefix("json").strip() for block in blocks[1::2]]
+    else:
+        candidates = [stripped]
+    candidates.extend(re.findall(r"\{(?:[^{}]|\"(?:\\.|[^\"\\])*\")*\}", stripped, flags=re.DOTALL))
+    for candidate in candidates:
+        try:
+            payload = json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(payload, dict):
+            continue
+        score = payload.get("score")
+        if not isinstance(score, (int, float)) or isinstance(score, bool):
+            continue
+        return {
+            "score": max(0, min(10, score)),
+            "category": str(payload.get("category") or "unknown"),
+            "outcome": str(payload.get("outcome") or ""),
+            "failure_reason": str(payload.get("failure_reason") or ""),
+        }
+    raise ValueError("judge response did not contain the required JSON object")
+
+
+def _judge_one(
+    checkout: Path,
+    ctx: OperatorContext,
+    config: dict[str, Any],
+    record: Case,
+    index: int,
+) -> Case:
+    attempts = _positive_int(ctx.config.get("judge_retry_attempts"), 3)
+    timeout_s = float(ctx.config.get("judge_timeout_s") or 600)
+    runner_ctx = replace(ctx, config=config)
+    slug = _safe_slug(str(record.get("task_id") or f"task-{index}"))
+    last_error = ""
+    for attempt in range(1, attempts + 1):
+        try:
+            result = run_readonly_agent(
+                checkout,
+                _runner_prompt(record, config),
+                runner_ctx,
+                output_dir=ctx.run_dir / "trace_analyzer" / "judge" / f"{index:04d}-{slug}" / f"attempt-{attempt}",
+                job_name=f"trajectory-judge-{index:04d}-{slug}-attempt-{attempt}",
+                timeout_s=timeout_s,
+            )
+            return _json_object(result.output)
+        except (AgentCommandError, OSError, RuntimeError, ValueError) as exc:
+            last_error = str(exc)
+    return {
+        "score": -1,
+        "category": "unknown",
+        "outcome": f"judge error: {last_error[:200]}",
+        "failure_reason": "",
+    }
+
+
+def _judge_records(checkout: Path, ctx: OperatorContext, records: list[Case]) -> list[Case]:
+    if not records:
+        return []
+    config = _runner_config(checkout)
+    workers = _positive_int(ctx.config.get("judge_max_concurrent"), 4)
+    verdicts: list[Case | None] = [None] * len(records)
+    with concurrent.futures.ThreadPoolExecutor(max_workers=workers) as pool:
+        futures = {
+            pool.submit(_judge_one, checkout, ctx, config, record, index): index for index, record in enumerate(records)
+        }
+        for future in concurrent.futures.as_completed(futures):
+            verdicts[futures[future]] = future.result()
+    return [verdict or {"score": -1} for verdict in verdicts]
+
+
+class TrajectoryOnly(TraceAnalyzerOperator):
+    def analyze(self, checkout: Path, ctx: OperatorContext) -> TraceAnalyzerResult:
+        cases_path = ctx.run_dir / "rollout" / "cases.json"
+        current = _load_cases(cases_path)
+        cases = _trajectory_only_cases(ctx, current)
+        records = trajectory_signal_records(cases)
+        verdicts = _judge_records(checkout, ctx, records)
+        max_chars = _positive_int(ctx.config.get("max_chars"), 30_000)
+        feedback, artifacts = write_evidence_bundle(
+            ctx.run_dir,
+            cases,
+            variant="trajectory_only",
+            max_chars=max_chars,
+            judge_verdicts=verdicts,
+        )
+        (ctx.run_dir / "trace_analyzer" / "feedback.md").write_text(feedback)
+        return TraceAnalyzerResult(
+            summary={
+                "variant": "trajectory_only",
+                "cases": len(records),
+                "judge_verdicts": sum(1 for verdict in verdicts if verdict.get("score", -1) >= 0),
+                "source": str(cases_path),
+            },
+            artifacts=["trace_analyzer/feedback.md", *artifacts],
+        )
+
+
+if __name__ == "__main__":
+    sdk.main(TrajectoryOnly)

--- a/recipes/README.md
+++ b/recipes/README.md
@@ -11,6 +11,7 @@ file is `library/gate/parent_eligible.py`.
 - [Hill Climb](hill_climb/README.md)
 - `hill_climb-smoke` — deterministic local counterpart
 - [A-Evolve](aevolve/README.md)
+- [A-Evolve Terminal-Bench Bridge](aevolve_tbench_bridge/README.md)
 - [Agentic Harness Engineering](ahe/README.md)
 - [GEPA](gepa/README.md)
 - [HyperAgents](hyperagents/README.md)

--- a/recipes/aevolve/README.md
+++ b/recipes/aevolve/README.md
@@ -3,10 +3,15 @@
 This recipe maps the default `AEvolveEngine` workspace-mutation pass from
 `a-evolve` onto Evolve's existing operator protocol.
 
-Each generation uses a fixed train split as the observation batch, retains
-complete execution records, summarizes observations from the latest two cycles
-(at most 30 cases), and asks an isolated Harbor editing agent to improve the
-built-in Codex target's prompt and reusable skills. Drafts under
+Each generation uses a fixed train split as the observation batch and converts
+Harbor's complete ordered events into A-Evolve's `trajectory_only` evidence:
+behavioral signals plus a failure-focused trajectory compression. A separate
+read-only Harbor judge estimates a score, category, outcome, and failure reason
+for each compressed trajectory. Pass/fail labels, reward, verifier feedback,
+task text, raw-case paths, and rollout history are omitted from both judge and
+editing prompts. The isolated Harbor editing agent then uses those proxy
+verdicts and behavior summaries to improve the built-in Codex target's prompt
+and reusable skills. Drafts under
 `target/skills/_drafts/` are included in the prompt and cleared after a
 successful evolution pass, matching `AEvolveEngine`.
 
@@ -15,16 +20,20 @@ The mapping is:
 | A-Evolve responsibility | Evolve implementation |
 | --- | --- |
 | solve tasks and retain observations | Harbor rollout |
-| recent observation history | `runs/gen-*/rollout/cases.json` |
-| build task summaries and review drafts | `meta_agent: aevolve` |
+| behavior-only observation view | `trace_analyzer: trajectory_only` |
+| infer likely outcomes | read-only per-task judge inside `trace_analyzer: trajectory_only` |
+| group patterns and review drafts | `meta_agent: aevolve` |
 | LLM with workspace shell access | Harbor meta-agent runner |
 | mutate prompt and skills | `target/prompt.md`, `target/skills/**` |
 | Git snapshots | generation tags |
 | holdout validation | disjoint gate split plus strict hill-climb gate |
 
-The full SkillForge orchestration has two optional capabilities that this
+The full SkillForge orchestration still has optional capabilities that this
 recipe does not claim to reproduce:
 
+- upstream's reference judge is hard-wired to a Bedrock model; this recipe
+  invokes the configured meta-agent model through Harbor with the same
+  behavior-only input and verdict schema;
 - the solver cannot currently return newly proposed draft skills into
   `target/skills/_drafts/`; the meta-agent will review drafts if another process
   places them there;

--- a/recipes/aevolve/evolve.yaml
+++ b/recipes/aevolve/evolve.yaml
@@ -19,6 +19,7 @@ operators:
   meta_agent:
     variant: aevolve
     trajectory_only: true
+    expose_gate_data: false
     runner: harbor
     agent: codex
     model: gpt-5.4

--- a/recipes/aevolve/evolve.yaml
+++ b/recipes/aevolve/evolve.yaml
@@ -15,9 +15,10 @@ surface:
 operators:
   select: {variant: greedy, timeout_s: 600}
   rollout: {variant: harbor, budget_tasks: 10, n_concurrent: 4, agent_setup_timeout_multiplier: 3, max_retries: 1, timeout_s: 3600}
-  trace_analyzer: {variant: execution_records, max_chars: 30000, timeout_s: 600}
+  trace_analyzer: {variant: trajectory_only, history_cycles: 2, max_observations: 30, max_chars: 30000, judge_max_concurrent: 4, judge_retry_attempts: 3, judge_timeout_s: 600, timeout_s: 3600}
   meta_agent:
     variant: aevolve
+    trajectory_only: true
     runner: harbor
     agent: codex
     model: gpt-5.4

--- a/recipes/aevolve_tbench_bridge/README.md
+++ b/recipes/aevolve_tbench_bridge/README.md
@@ -1,0 +1,14 @@
+# A-Evolve Terminal-Bench Bridge
+
+Runs A-Evolve for ten generations with a MiniSWE source target, Codex as the
+Harbor-hosted meta-agent, and a local OpenAI-compatible Responses bridge for
+target rollouts. Supply the local MiniSWE seed and Terminal-Bench dataset with
+`evolve init --seed ... --dataset ...`.
+
+The A-Evolve meta-agent may evolve the MiniSWE runtime prompt, reusable skills,
+and JSONL memory; tools remain disabled. During each rollout the fixed Harbor
+adapter discovers `target/skills/*/SKILL.md`, adds the skill names,
+descriptions, and readable container paths to MiniSWE's system prompt, and
+injects the last 100 entries from `target/memory/*.jsonl`. The complete skill
+body stays lazy-loaded: MiniSWE reads the referenced `SKILL.md` with its bash
+tool when the skill is relevant.

--- a/recipes/aevolve_tbench_bridge/evolve.yaml
+++ b/recipes/aevolve_tbench_bridge/evolve.yaml
@@ -1,0 +1,97 @@
+experiment:
+  id: aevolve-tbench-bridge
+  max_generations: 10
+  target_score: null
+  budget_usd: 150
+  children_per_gen: 1
+  mode: driver
+  seed: 0
+target:
+  seed: builtin-codex
+  harbor_agent: miniswe-source
+surface:
+  include:
+    - target/**
+  exclude: []
+operators:
+  select: {variant: greedy, timeout_s: 600}
+  rollout:
+    variant: harbor
+    budget_tasks: 10
+    n_concurrent: 10
+    agent_setup_timeout_multiplier: 3
+    agent_timeout_multiplier: 4
+    max_retries: 15
+    timeout_s: 43200
+  trace_analyzer:
+    variant: trajectory_only
+    history_cycles: 2
+    max_observations: 30
+    max_chars: 60000
+    judge_max_concurrent: 10
+    judge_retry_attempts: 3
+    judge_timeout_s: 600
+    timeout_s: 7200
+  meta_agent:
+    variant: aevolve
+    trajectory_only: true
+    expose_gate_data: false
+    runner: harbor
+    agent: codex
+    model: gpt-5.4
+    environment: docker
+    image: evolve-meta-agent-app:ubuntu-latest
+    editable_roots: [target]
+    evolve_prompts: true
+    evolve_skills: true
+    evolve_memory: true
+    evolve_tools: false
+    prompt_path: target/src/minisweagent/config/mini.yaml
+    skills_dir: target/skills
+    memory_dir: target/memory
+    tools_dir: target/tools
+    history_cycles: 2
+    max_observations: 30
+    feedback_chars: 600
+    evidence_chars: 50000
+    max_retries: 2
+    timeout_s: 7200
+    agent_kwargs:
+      reasoning_effort: xhigh
+  gate: {variant: hillclimb, strict: true, timeout_s: 43200}
+  record: {variant: jsonl, timeout_s: 600}
+  timeout_s: 600
+evaluator:
+  engine: harbor
+  dataset: swe-bench-lite
+  model: openai/gpt-5.4-2026-03-05
+  agent: evolve_harbor_adapter:MiniSweSourceAgent
+  candidate_runtime:
+    variant: uv
+    project: target
+    python: "3.12"
+  agent_env:
+    OPENAI_BASE_URL: http://172.17.0.1:18788/v1
+    OPENAI_API_BASE: http://172.17.0.1:18788/v1
+    NO_PROXY: 172.17.0.1,127.0.0.1,localhost
+    no_proxy: 172.17.0.1,127.0.0.1,localhost
+    MINISWE_CONFIG: mini
+    MINISWE_REASONING_EFFORT: high
+    MINISWE_MAX_OUTPUT_LIMIT: "10000"
+    MINISWE_STEP_LIMIT: "100"
+    MINISWE_COST_LIMIT: "3.0"
+    MINISWE_ENV_TIMEOUT: "30"
+  split:
+    train: 0.3333333333333333
+    gate: 0.3333333333333333
+    sealed: 0.3333333333333333
+    seed: 0
+  sampling: static
+  tasks_per_round: 10
+  anchor: {final: true, every_rounds: 0}
+  k: 1
+  n_concurrent: 10
+  agent_setup_timeout_multiplier: 3
+  agent_timeout_multiplier: 4
+  max_retries: 15
+  partial_floor: 0.8

--- a/recipes/ahe/evolve.yaml
+++ b/recipes/ahe/evolve.yaml
@@ -16,7 +16,7 @@ operators:
   select: {variant: ahe_latest, timeout_s: 600}
   rollout: {variant: evaluation_replay, field_limit: 2000, timeout_s: 600}
   trace_analyzer: {variant: ahe, max_tasks: 90, max_concurrent: 4, timeout_per_task: 600, retry_attempts: 3, field_limit: 2000, timeout_s: 3600}
-  meta_agent: {variant: ahe, runner: harbor, agent: evolve_harbor_agent:FileTaskMiniSweAgent, model: openai/gpt-5.4-2026-03-05, environment: docker, image: evolve-meta-agent-app:ubuntu-latest, editable_roots: [target], prompt_path: target/src/minisweagent/config/mini.yaml, skills_dir: target/skills, memory_dir: target/memory, tools_dir: target/tools, agent_kwargs: {reasoning_effort: xhigh, cost_limit: 0}, max_retries: 2, timeout_s: 3600}
+  meta_agent: {variant: ahe, runner: harbor, expose_gate_data: true, agent: evolve_harbor_agent:FileTaskMiniSweAgent, model: openai/gpt-5.4-2026-03-05, environment: docker, image: evolve-meta-agent-app:ubuntu-latest, editable_roots: [target], prompt_path: target/src/minisweagent/config/mini.yaml, skills_dir: target/skills, memory_dir: target/memory, tools_dir: target/tools, agent_kwargs: {reasoning_effort: xhigh, cost_limit: 0}, max_retries: 2, timeout_s: 3600}
   gate: {variant: ahe_artifact_valid, timeout_s: 600}
   record: {variant: jsonl, timeout_s: 600}
   timeout_s: 600

--- a/recipes/ahe/evolve.yaml
+++ b/recipes/ahe/evolve.yaml
@@ -16,7 +16,7 @@ operators:
   select: {variant: ahe_latest, timeout_s: 600}
   rollout: {variant: evaluation_replay, field_limit: 2000, timeout_s: 600}
   trace_analyzer: {variant: ahe, max_tasks: 90, max_concurrent: 4, timeout_per_task: 600, retry_attempts: 3, field_limit: 2000, timeout_s: 3600}
-  meta_agent: {variant: ahe, runner: harbor, agent: evolve_harbor_agent:FileTaskMiniSweAgent, model: openai/gpt-5.4-2026-03-05, environment: docker, image: evolve-meta-agent-app:ubuntu-latest, editable_roots: [target], agent_kwargs: {reasoning_effort: xhigh, cost_limit: 0}, max_retries: 2, timeout_s: 3600}
+  meta_agent: {variant: ahe, runner: harbor, agent: evolve_harbor_agent:FileTaskMiniSweAgent, model: openai/gpt-5.4-2026-03-05, environment: docker, image: evolve-meta-agent-app:ubuntu-latest, editable_roots: [target], prompt_path: target/src/minisweagent/config/mini.yaml, skills_dir: target/skills, memory_dir: target/memory, tools_dir: target/tools, agent_kwargs: {reasoning_effort: xhigh, cost_limit: 0}, max_retries: 2, timeout_s: 3600}
   gate: {variant: ahe_artifact_valid, timeout_s: 600}
   record: {variant: jsonl, timeout_s: 600}
   timeout_s: 600

--- a/recipes/gepa/README.md
+++ b/recipes/gepa/README.md
@@ -5,17 +5,20 @@ Harbor evaluator:
 
 1. sample a parent according to its per-task Pareto-front coverage;
 2. run the parent on a generation-shuffled train minibatch with Harbor;
-3. turn each Harbor trajectory into component-specific reflective examples;
-4. ask the GEPA meta-agent to improve one configured component;
+3. write each component's reflective examples to a structured evidence file;
+4. give the GEPA meta-agent a short proposal brief pointing to those evidence
+   files and let it edit the live target;
 5. run the child with Harbor on the exact same minibatch and require a strict
    total-score improvement;
 6. evaluate an improving child on the canonical gate set and add every eligible
    result to the population.
 
 The default components are `target/prompt.md` and the task-execution skill. The
-component strategy is round-robin, so one component is changed per generation.
-Set `component_strategy: all` to expose all configured components to one
-proposal.
+component strategy is round-robin, so one component's evidence and paths guide
+each generation. Set `component_strategy: all` to expose all configured
+components to one proposal. Components are proposal focus areas, not narrower
+mutation permissions: the meta-agent may edit any path allowed by the mutable
+surface.
 
 This implements GEPA's Pareto selection, execution-aware reflection, component
 mutation, and minibatch acceptance. GEPA's optional system-aware merge proposal
@@ -36,6 +39,7 @@ The most useful artifacts are:
 
 - `runs/gen-*/select/pareto.json`
 - `runs/gen-*/trace_analyzer/evidence/reflective_dataset.json`
+- `runs/gen-*/trace_analyzer/evidence/reflection/*.json`
 - `runs/gen-*/meta_agent/proposal.json`
 - `runs/gen-*/validate/comparison.json`
 - `runs/gen-*/record/gepa-experience.json`

--- a/recipes/gepa/evolve.yaml
+++ b/recipes/gepa/evolve.yaml
@@ -25,6 +25,7 @@ operators:
     timeout_s: 600
   meta_agent:
     variant: gepa
+    expose_gate_data: false
     runner: harbor
     agent: codex
     model: gpt-5.4

--- a/recipes/hill_climb/evolve.yaml
+++ b/recipes/hill_climb/evolve.yaml
@@ -17,7 +17,7 @@ operators:
   select: {variant: greedy}
   rollout: {variant: harbor, budget_tasks: 32, n_concurrent: 16, agent_setup_timeout_multiplier: 3, max_retries: 1, timeout_s: 3600}
   trace_analyzer: {variant: failure_patterns, max_chars: 30000, timeout_s: 600}
-  meta_agent: {variant: hyperagents, runner: harbor, agent: codex, model: gpt-5.4, environment: docker, editable_roots: [target], prompt_path: target/src/minisweagent/config/mini.yaml, skills_dir: target/skills, memory_dir: target/memory, tools_dir: target/tools, max_retries: 0, timeout_s: 3600}
+  meta_agent: {variant: hyperagents, runner: harbor, expose_gate_data: false, agent: codex, model: gpt-5.4, environment: docker, editable_roots: [target], prompt_path: target/src/minisweagent/config/mini.yaml, skills_dir: target/skills, memory_dir: target/memory, tools_dir: target/tools, max_retries: 0, timeout_s: 3600}
   gate: {variant: hillclimb}
   record: {variant: jsonl}
   timeout_s: 600

--- a/recipes/hill_climb/evolve.yaml
+++ b/recipes/hill_climb/evolve.yaml
@@ -17,7 +17,7 @@ operators:
   select: {variant: greedy}
   rollout: {variant: harbor, budget_tasks: 32, n_concurrent: 16, agent_setup_timeout_multiplier: 3, max_retries: 1, timeout_s: 3600}
   trace_analyzer: {variant: failure_patterns, max_chars: 30000, timeout_s: 600}
-  meta_agent: {variant: hyperagents, runner: harbor, agent: codex, model: gpt-5.4, environment: docker, max_retries: 0, timeout_s: 3600}
+  meta_agent: {variant: hyperagents, runner: harbor, agent: codex, model: gpt-5.4, environment: docker, editable_roots: [target], prompt_path: target/src/minisweagent/config/mini.yaml, skills_dir: target/skills, memory_dir: target/memory, tools_dir: target/tools, max_retries: 0, timeout_s: 3600}
   gate: {variant: hillclimb}
   record: {variant: jsonl}
   timeout_s: 600

--- a/recipes/hyperagents/evolve.yaml
+++ b/recipes/hyperagents/evolve.yaml
@@ -17,7 +17,7 @@ operators:
   select: {variant: score_child_prop, seed: 0}
   rollout: {variant: evaluation_replay, field_limit: 2000, timeout_s: 600}
   trace_analyzer: {variant: trace_browser, max_chars: 30000, timeout_s: 600}
-  meta_agent: {variant: hyperagents, runner: harbor, agent: evolve_harbor_agent:FileTaskMiniSweAgent, model: openai/gpt-5.4-2026-03-05, environment: docker, image: evolve-meta-agent-app:ubuntu-latest, editable_roots: [target, operators], prompt_path: target/src/minisweagent/config/mini.yaml, skills_dir: target/skills, memory_dir: target/memory, tools_dir: target/tools, agent_kwargs: {reasoning_effort: high, cost_limit: 0}, max_retries: 2, timeout_s: 21600}
+  meta_agent: {variant: hyperagents, runner: harbor, expose_gate_data: true, agent: evolve_harbor_agent:FileTaskMiniSweAgent, model: openai/gpt-5.4-2026-03-05, environment: docker, image: evolve-meta-agent-app:ubuntu-latest, editable_roots: [target, operators], prompt_path: target/src/minisweagent/config/mini.yaml, skills_dir: target/skills, memory_dir: target/memory, tools_dir: target/tools, agent_kwargs: {reasoning_effort: high, cost_limit: 0}, max_retries: 2, timeout_s: 21600}
   validate: {variant: hyperagents, timeout_s: 300}
   gate: {variant: parent_eligible}
   record: {variant: hyperagents}

--- a/recipes/hyperagents/evolve.yaml
+++ b/recipes/hyperagents/evolve.yaml
@@ -17,7 +17,7 @@ operators:
   select: {variant: score_child_prop, seed: 0}
   rollout: {variant: evaluation_replay, field_limit: 2000, timeout_s: 600}
   trace_analyzer: {variant: trace_browser, max_chars: 30000, timeout_s: 600}
-  meta_agent: {variant: hyperagents, runner: harbor, agent: evolve_harbor_agent:FileTaskMiniSweAgent, model: openai/gpt-5.4-2026-03-05, environment: docker, image: evolve-meta-agent-app:ubuntu-latest, editable_roots: [target, operators], agent_kwargs: {reasoning_effort: high, cost_limit: 0}, max_retries: 2, timeout_s: 21600}
+  meta_agent: {variant: hyperagents, runner: harbor, agent: evolve_harbor_agent:FileTaskMiniSweAgent, model: openai/gpt-5.4-2026-03-05, environment: docker, image: evolve-meta-agent-app:ubuntu-latest, editable_roots: [target, operators], prompt_path: target/src/minisweagent/config/mini.yaml, skills_dir: target/skills, memory_dir: target/memory, tools_dir: target/tools, agent_kwargs: {reasoning_effort: high, cost_limit: 0}, max_retries: 2, timeout_s: 21600}
   validate: {variant: hyperagents, timeout_s: 300}
   gate: {variant: parent_eligible}
   record: {variant: hyperagents}

--- a/src/evolve/driver.py
+++ b/src/evolve/driver.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
+import fcntl
 import json
 import os
 import tempfile
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, TextIO
 
 from .archive import (
     EVALUATION_FIELDS,
@@ -98,8 +100,40 @@ class OperatorOutputError:
     detail: str
 
 
+@contextmanager
+def workspace_run_lock(workspace: Path) -> Iterator[None]:
+    lock_path = workspace / "runs" / ".driver.lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    handle: TextIO = lock_path.open("a+", encoding="utf-8")
+    try:
+        try:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except BlockingIOError as exc:
+            handle.seek(0)
+            owner = handle.read().strip() or "unknown"
+            raise RuntimeError(
+                f"another evolve run already owns workspace {workspace} (pid {owner}); "
+                "stop it before starting a second run"
+            ) from exc
+        handle.seek(0)
+        handle.truncate()
+        handle.write(f"{os.getpid()}\n")
+        handle.flush()
+        yield
+    finally:
+        try:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        finally:
+            handle.close()
+
+
 def run(options: RunOptions) -> None:
     workspace = options.workspace.resolve()
+    with workspace_run_lock(workspace):
+        _run_locked(options, workspace)
+
+
+def _run_locked(options: RunOptions, workspace: Path) -> None:
     if options.children_per_gen < 1:
         raise RuntimeError("children_per_gen must be at least 1")
     exp_id = experiment_id(workspace)

--- a/src/evolve/evaluation/execution.py
+++ b/src/evolve/evaluation/execution.py
@@ -10,7 +10,7 @@ from typing import Any
 
 from ..config import evaluator_boolean, evaluator_sampling, experiment_id, load_config
 from ..git import evaluator_tree, git, git_stdout
-from ..host_runtime import clean_python_env, workspace_temp_dir
+from ..host_runtime import clean_python_env
 from ..runtime import OwnedResult, attempt_dir, next_attempt, owned_attempt_id, run_owned
 from ..splits import harbor_task_pattern
 from ..uv_runtime import CandidateRuntimeResult, prepare_candidate_runtime
@@ -41,7 +41,7 @@ def evaluate(
     evaluator_fingerprint = evaluator_tree(workspace, tag)
     if evaluator_fingerprint != evaluator_tree(workspace, "gen/0"):
         raise RuntimeError(f"evaluator tree for {tag} differs from gen/0")
-    with tempfile.TemporaryDirectory(prefix="evolve-eval-", dir=workspace_temp_dir(workspace)) as tempdir:
+    with tempfile.TemporaryDirectory(prefix="evolve-eval-") as tempdir:
         checkout = Path(tempdir) / "checkout"
         git(workspace, "worktree", "add", "--detach", str(checkout), candidate_commit)
         cleanup_needed = True
@@ -296,7 +296,6 @@ def _run_eval_script(
         "EVOLVE_WORKSPACE": str(runs_dir.parent.resolve()),
     }
     env["EVOLVE_EVAL_SPLIT"] = evaluation_split
-    env["TMPDIR"] = str(workspace_temp_dir(runs_dir.parent))
     if runtime.variant is not None:
         env["EVOLVE_CANDIDATE_RUNTIME_ENV_JSON"] = runtime.environment_json()
         env["EVOLVE_CANDIDATE_RUNTIME_MOUNTS_JSON"] = runtime.mounts_json()

--- a/src/evolve/feedback.py
+++ b/src/evolve/feedback.py
@@ -80,6 +80,7 @@ def _copy_trace_evidence(run_dir: Path, destination: Path) -> list[str]:
     for name in (
         "manifest.json",
         "selected.md",
+        "trajectory_only.json",
         "metrics.json",
         "failure_patterns.json",
         "passing_behaviors.json",

--- a/src/evolve/host_runtime.py
+++ b/src/evolve/host_runtime.py
@@ -16,16 +16,6 @@ def clean_python_env(source: Mapping[str, str] | None = None) -> dict[str, str]:
     return env
 
 
-def workspace_temp_dir(workspace: Path) -> Path:
-    """Return a persistent-volume temp root for framework and child processes."""
-    configured = os.environ.get("EVOLVE_TMPDIR")
-    root = Path(configured).expanduser() if configured else workspace / "runs" / ".tmp"
-    if not root.is_absolute():
-        root = workspace / root
-    root.mkdir(parents=True, exist_ok=True)
-    return root
-
-
 def uv_executable(env: Mapping[str, str] | None = None) -> str:
     """Resolve uv from the explicit Evolve override or the supplied PATH."""
     values = os.environ if env is None else env
@@ -44,7 +34,6 @@ def uv_run(
     """Build a locked uv invocation for a generated workspace."""
     clean = clean_python_env(env)
     root = workspace.resolve()
-    clean["TMPDIR"] = str(workspace_temp_dir(root))
     for name in ("pyproject.toml", "uv.lock"):
         path = root / name
         if not path.is_file():

--- a/src/evolve/trace_analysis.py
+++ b/src/evolve/trace_analysis.py
@@ -16,6 +16,7 @@ VARIANTS = (
     "failure_patterns",
     "failed_traces",
     "trace_browser",
+    "trajectory_only",
     "execution_records",
     "utility_metrics",
 )
@@ -235,6 +236,212 @@ def reflective_records(cases: list[Case]) -> list[Case]:
     ]
 
 
+def _tool_arguments(value: object) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return {str(key): item for key, item in value.items()}
+    if not isinstance(value, str):
+        return {}
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _ordered_behavior_events(case: Case) -> list[Case]:
+    """Normalize Harbor's two ordered-event shapes without using labels."""
+    normalized: list[Case] = []
+    for event in case.get("trajectory_events") or case.get("events") or []:
+        if not isinstance(event, dict):
+            continue
+        event_type = str(event.get("type") or "")
+        source = str(event.get("source") or "")
+        if event_type == "message":
+            if source == "agent":
+                normalized.append({"type": "turn"})
+            continue
+        if event_type == "tool_call":
+            normalized.append(
+                {
+                    "type": "tool_call",
+                    "name": str(event.get("name") or "unknown"),
+                    "arguments": event.get("arguments") or {},
+                }
+            )
+            continue
+        if event_type == "tool_result":
+            normalized.append(
+                {
+                    "type": "tool_result",
+                    "observation": str(event.get("observation") or ""),
+                }
+            )
+            continue
+
+        # Harbor trajectory.json steps keep calls and results together.
+        if source == "agent":
+            normalized.append({"type": "turn"})
+        for call in event.get("tool_calls") or []:
+            if isinstance(call, dict):
+                normalized.append(
+                    {
+                        "type": "tool_call",
+                        "name": str(call.get("name") or "unknown"),
+                        "arguments": call.get("arguments") or {},
+                    }
+                )
+        for observation in event.get("observations") or []:
+            normalized.append({"type": "tool_result", "observation": str(observation)})
+    return normalized
+
+
+def _trajectory_signals(case: Case) -> dict[str, Any]:
+    n_turns = 0
+    n_tool_calls = 0
+    n_errors = 0
+    n_timeouts = 0
+    tools_used: dict[str, int] = {}
+    commands_run: list[str] = []
+    submitted = False
+    submit_value = ""
+    error_messages: list[str] = []
+
+    for event in _ordered_behavior_events(case):
+        if event["type"] == "turn":
+            n_turns += 1
+        elif event["type"] == "tool_call":
+            n_tool_calls += 1
+            name = str(event.get("name") or "")
+            tools_used[name] = tools_used.get(name, 0) + 1
+            arguments = _tool_arguments(event.get("arguments"))
+            command = arguments.get("cmd") or arguments.get("command")
+            if command:
+                commands_run.append(str(command)[:80])
+            if name in {"submit", "task_submit"}:
+                submitted = True
+                submit_value = str(arguments.get("answer") or "")
+        elif event["type"] == "tool_result":
+            content = str(event.get("observation") or "")
+            lowered = content.lower()
+            if "ERROR:" in content or "error:" in lowered[:50]:
+                n_errors += 1
+                error_messages.append(content[:100])
+            if "timed out" in lowered or "timeout" in lowered:
+                n_timeouts += 1
+
+    command_counts = Counter(commands_run)
+    return {
+        "n_turns": n_turns,
+        "n_tool_calls": n_tool_calls,
+        "n_errors": n_errors,
+        "n_timeouts": n_timeouts,
+        "tools_used": tools_used,
+        "submitted": submitted,
+        "submit_value": submit_value,
+        "repeated_commands": [command for command, count in command_counts.items() if count >= 3],
+        "error_snippets": error_messages[:5],
+    }
+
+
+def _compress_trajectory(case: Case) -> str:
+    """Mirror A-Evolve's failure-focused trajectory-only compression."""
+    events: list[Case] = []
+    previous_command = ""
+    for event in _ordered_behavior_events(case):
+        if event["type"] == "tool_call":
+            name = str(event.get("name") or "")
+            arguments = _tool_arguments(event.get("arguments"))
+            command = arguments.get("cmd") or arguments.get("command") or arguments.get("code")
+            if name in {"submit", "task_submit"}:
+                events.append({"type": "submit", "value": str(arguments.get("answer") or "")})
+            elif command:
+                previous_command = str(command)[:200]
+                events.append(
+                    {
+                        "type": "cmd",
+                        "name": name,
+                        "command": previous_command,
+                    }
+                )
+        elif event["type"] == "tool_result":
+            content = str(event.get("observation") or "").strip()
+            lowered = content.lower()
+            is_error = (
+                "ERROR:" in content
+                or "error:" in lowered[:80]
+                or "Traceback" in content[:200]
+                or "TIMEOUT" in content.upper()[:50]
+                or "timed out" in lowered[:80]
+                or "No such file" in content[:100]
+                or "command not found" in content[:100]
+            )
+            if is_error:
+                events.append(
+                    {
+                        "type": "error",
+                        "command": previous_command,
+                        "output": content[:300],
+                    }
+                )
+
+    commands = [event for event in events if event["type"] == "cmd"]
+    errors = [event for event in events if event["type"] == "error"]
+    submissions = [event for event in events if event["type"] == "submit"]
+    parts = [f"Commands: {len(commands)}, Errors: {len(errors)}, Submitted: {bool(submissions)}"]
+    for event in commands[:3]:
+        parts.append(f"[start] {event['name']}({event['command']})")
+    if errors:
+        parts.append(f"\n--- Errors ({len(errors)}) ---")
+        for event in errors:
+            parts.append(f"  cmd: {event.get('command') or '?'}")
+            parts.append(f"  err: {str(event['output'])[:200]}")
+
+    command_counts = Counter(str(event["command"]) for event in commands)
+    repeated = [(command, count) for command, count in command_counts.items() if count >= 3]
+    if repeated:
+        parts.append("\n--- Repeated commands ---")
+        for command, count in repeated:
+            parts.append(f"  {command} (x{count})")
+    if commands:
+        parts.append("\n--- Final commands ---")
+        for event in commands[-3:]:
+            parts.append(f"  {event['name']}({event['command']})")
+    if submissions:
+        parts.append(f"\n[submitted] {submissions[-1].get('value') or ''}")
+    return "\n".join(parts)
+
+
+def trajectory_signal_records(cases: list[Case]) -> list[Case]:
+    """Return the exact evidence fields exposed by A-Evolve trajectory-only mode."""
+    return [
+        {
+            "task_id": case.get("task_name") or case.get("trial_name") or "",
+            "signals": _trajectory_signals(case),
+            "compressed_trajectory": _compress_trajectory(case),
+        }
+        for case in cases
+        if case.get("outcome") not in {"infra_error", "incomplete"}
+    ]
+
+
+def attach_judge_verdicts(records: list[Case], verdicts: list[Case]) -> list[Case]:
+    """Attach only valid official-style proxy verdicts, preserving record order."""
+    judged: list[Case] = []
+    for index, record in enumerate(records):
+        enriched = dict(record)
+        verdict = verdicts[index] if index < len(verdicts) else {}
+        score = verdict.get("score") if isinstance(verdict, dict) else None
+        if isinstance(score, (int, float)) and not isinstance(score, bool) and score >= 0:
+            enriched["judge_verdict"] = {
+                "score": max(0, min(10, score)),
+                "category": str(verdict.get("category") or "unknown"),
+                "outcome": str(verdict.get("outcome") or ""),
+                "failure_reason": str(verdict.get("failure_reason") or ""),
+            }
+        judged.append(enriched)
+    return judged
+
+
 def _metrics(cases: list[Case]) -> Case:
     outcomes = Counter(str(case.get("outcome") or "unknown") for case in cases)
     rewards = [float(case["reward"]) for case in cases if isinstance(case.get("reward"), (int, float))]
@@ -259,6 +466,7 @@ _VARIANT_GUIDANCE = {
     "failure_patterns": "Prioritize recurring, actionable failure signatures. Preserve passing behaviors and propose a narrow edit tied to one agent mechanism.",
     "failed_traces": "Diagnose concrete capability weaknesses from failed executions and make a change that generalizes beyond one task.",
     "trace_browser": "Use filesystem tools to inspect raw traces, metrics, source, and prior generations instead of relying only on this bounded summary.",
+    "trajectory_only": "Infer improvement opportunities from agent behavior alone. No pass/fail labels, rewards, verifier feedback, task text, or raw-case paths are exposed.",
     "execution_records": "Reflect across complete per-case inputs, outputs, ordered actions, tool results, verifier feedback, metrics, and history.",
     "utility_metrics": "Treat per-task reward as downstream utility and improve the editable component for average utility across tasks.",
 }
@@ -271,7 +479,27 @@ def _render_selected(
     passes: list[Case],
     reflections: list[Case],
     max_chars: int,
+    trajectory_records: list[Case] | None = None,
 ) -> str:
+    if variant == "trajectory_only":
+        rendered = (
+            "### Agent Behavior Analysis (this batch)\n\n"
+            "You can ONLY see the agent's actions. You do NOT have access to actual test results.\n\n"
+            "Each task includes:\n"
+            "- `signals`: automated behavioral metrics (turns, errors, timeouts, submission status, loops)\n"
+            "- `compressed_trajectory`: failure-focused summary (approach, errors, loops, final actions)\n"
+            "- `judge_verdict`: a behavior-only LLM estimate with score (0-10), category, outcome, "
+            "and failure_reason; it is not evaluator ground truth\n\n"
+            "Sort tasks by judge score. Prioritize scores 0-3, inspect scores 4-6 as partial progress, "
+            "and normally skip scores 7-10. Group recurring categories and failure reasons before editing.\n\n"
+            "```json\n"
+            f"{json.dumps(trajectory_records or [], indent=2, sort_keys=True)}\n"
+            "```\n"
+        )
+        if len(rendered) <= max_chars:
+            return rendered
+        return rendered[:max_chars] + f"\n...[behavior evidence truncated {len(rendered) - max_chars} chars]...\n"
+
     lines = [
         "# Trace Analysis Feedback",
         "",
@@ -331,6 +559,7 @@ def write_evidence_bundle(
     *,
     variant: object = "failure_patterns",
     max_chars: int = 30000,
+    judge_verdicts: list[Case] | None = None,
 ) -> tuple[str, list[str]]:
     """Persist method-neutral evidence once and render a bounded selected view."""
     selected = normalize_variant(variant)
@@ -340,6 +569,38 @@ def write_evidence_bundle(
     passes = passing_behaviors(cases)
     reflections = reflective_records(cases)
     metrics = _metrics(cases)
+    trajectory_records = trajectory_signal_records(cases)
+    if judge_verdicts is not None:
+        trajectory_records = attach_judge_verdicts(trajectory_records, judge_verdicts)
+
+    if selected == "trajectory_only":
+        _write_json(root / "trajectory_only.json", trajectory_records)
+        manifest = {
+            "selected_variant": selected,
+            "cases": len(trajectory_records),
+            "evidence_policy": "trajectory_only",
+            "ground_truth_exposed": False,
+            "case_paths_exposed": False,
+            "variants": {
+                "trajectory_only": ["trajectory_only.json", "selected.md"],
+            },
+        }
+        _write_json(root / "manifest.json", manifest)
+        selected_md = _render_selected(
+            selected,
+            {},
+            [],
+            [],
+            [],
+            max_chars,
+            trajectory_records=trajectory_records,
+        )
+        (root / "selected.md").write_text(selected_md)
+        return selected_md, [
+            "trace_analyzer/evidence/manifest.json",
+            "trace_analyzer/evidence/trajectory_only.json",
+            "trace_analyzer/evidence/selected.md",
+        ]
 
     _write_jsonl(root / "raw_traces.jsonl", cases)
     _write_json(root / "failure_records.json", records)
@@ -381,6 +642,41 @@ def _load_cases(path: Path) -> list[Case]:
     return [row for row in payload if isinstance(row, dict)] if isinstance(payload, list) else []
 
 
+def _positive_int(value: object, default: int) -> int:
+    try:
+        return max(1, int(str(value)))
+    except (TypeError, ValueError):
+        return default
+
+
+def _trajectory_only_cases(ctx: OperatorContext, current: list[Case]) -> list[Case]:
+    """Follow the selected lineage and mirror AEvolveEngine's recent-log window."""
+    history_cycles = _positive_int(ctx.config.get("history_cycles"), 2)
+    maximum = _positive_int(ctx.config.get("max_observations"), 30)
+    prior: list[list[Case]] = []
+    parent = str(ctx.parent or "")
+    rows: dict[str, dict[str, Any]] = {}
+    try:
+        from evolve.archive import rows_by_genid
+
+        rows = rows_by_genid(ctx.workspace)
+    except (OSError, KeyError, TypeError, ValueError, json.JSONDecodeError):
+        rows = {}
+
+    seen: set[str] = set()
+    while parent and parent not in seen and len(prior) < history_cycles - 1:
+        seen.add(parent)
+        cases = _load_cases(ctx.workspace / "runs" / f"gen-{parent}" / "rollout" / "cases.json")
+        if cases:
+            prior.append(cases)
+        row = rows.get(parent) or {}
+        parent = str(row.get("parent") or "")
+
+    combined = [case for batch in reversed(prior) for case in batch]
+    combined.extend(current)
+    return combined[-maximum:]
+
+
 class TraceAnalyzerBase(TraceAnalyzerOperator):
     variant = "failure_patterns"
 
@@ -389,15 +685,16 @@ class TraceAnalyzerBase(TraceAnalyzerOperator):
         selected = normalize_variant(self.variant)
         cases_path = ctx.run_dir / "rollout" / "cases.json"
         cases = _load_cases(cases_path)
+        analysis_cases = _trajectory_only_cases(ctx, cases) if selected == "trajectory_only" else cases
         max_chars = max(1, int(ctx.config.get("max_chars", 30000)))
         feedback, artifacts = write_evidence_bundle(
             ctx.run_dir,
-            cases,
+            analysis_cases,
             variant=selected,
             max_chars=max_chars,
         )
         (ctx.run_dir / "trace_analyzer" / "feedback.md").write_text(feedback)
         return TraceAnalyzerResult(
-            summary={"variant": selected, "cases": len(cases), "source": str(cases_path)},
+            summary={"variant": selected, "cases": len(analysis_cases), "source": str(cases_path)},
             artifacts=["trace_analyzer/feedback.md", *artifacts],
         )

--- a/templates/target/harbor/miniswe_source_agent.py
+++ b/templates/target/harbor/miniswe_source_agent.py
@@ -208,8 +208,8 @@ class MiniSweSourceAgent(MiniSweAgent):
     async def _runtime_phase(self, environment, command: str, code: str, *, env: dict[str, str]) -> None:
         try:
             await self.exec_as_agent(environment, command=command, env=env)
-        except Exception:
-            raise EvolveRuntimeInfrastructureError(f"EVOLVE_RUNTIME_INFRASTRUCTURE: {code}") from None
+        except Exception as error:
+            raise EvolveRuntimeInfrastructureError(f"EVOLVE_RUNTIME_INFRASTRUCTURE: {code}: {error}") from None
 
     def _preflight_command(self, marker: str, script: str) -> str:
         return (

--- a/templates/target/harbor/miniswe_source_agent.py
+++ b/templates/target/harbor/miniswe_source_agent.py
@@ -70,8 +70,88 @@ def build_model(config):
 """.strip()
 
 
+EVOLVED_CONTEXT_SETUP = r"""
+import json
+from pathlib import Path
+
+import yaml
+
+
+def _load_evolved_context(source_dir):
+    source_root = Path(source_dir)
+    skills = []
+    skills_dir = source_root / "skills"
+    if skills_dir.is_dir():
+        for skill_file in sorted(skills_dir.glob("*/SKILL.md")):
+            if skill_file.parent.name.startswith("_"):
+                continue
+            text = skill_file.read_text()
+            metadata = {}
+            if text.startswith("---"):
+                parts = text.split("---", 2)
+                if len(parts) == 3:
+                    metadata = yaml.safe_load(parts[1]) or {}
+                    if not isinstance(metadata, dict):
+                        raise ValueError(f"Skill frontmatter must be a mapping: {skill_file}")
+            skills.append(
+                {
+                    "name": str(metadata.get("name") or skill_file.parent.name),
+                    "description": str(metadata.get("description") or "").strip(),
+                    "path": skill_file,
+                }
+            )
+
+    memories = []
+    memory_dir = source_root / "memory"
+    if memory_dir.is_dir():
+        for memory_file in sorted(memory_dir.glob("*.jsonl")):
+            for line_number, line in enumerate(memory_file.read_text().splitlines(), 1):
+                if not line.strip():
+                    continue
+                entry = json.loads(line)
+                if not isinstance(entry, dict):
+                    raise ValueError(f"Memory entry must be an object: {memory_file}:{line_number}")
+                memories.append(entry)
+    memories = memories[-100:]
+
+    sections = []
+    if skills:
+        lines = [
+            "## Available Skills",
+            "",
+            "Reusable procedures are available below. Before a relevant task, use the bash tool to read the "
+            "referenced `SKILL.md` file and follow its full procedure.",
+        ]
+        for skill in skills:
+            description = f": {skill['description']}" if skill["description"] else ""
+            lines.append(f"- **{skill['name']}**{description} (file: `{skill['path']}`)")
+        sections.append("\n".join(lines))
+    if memories:
+        lines = [
+            "## Evolved Memory",
+            "",
+            "These are transferable observations retained from earlier task trajectories. Apply them only when "
+            "relevant to the current task.",
+        ]
+        lines.extend(f"- {json.dumps(entry, ensure_ascii=False, sort_keys=True)}" for entry in memories)
+        sections.append("\n".join(lines))
+    text = "\n\n".join(sections)
+    return text, {"skills_loaded": len(skills), "memories_loaded": len(memories)}
+
+
+def _apply_evolved_context(agent_kwargs, source_dir):
+    context, stats = _load_evolved_context(source_dir)
+    if context:
+        system_template = str(agent_kwargs.get("system_template") or "").rstrip()
+        agent_kwargs["system_template"] = f"{system_template}\n\n{context}\n"
+    return stats
+""".strip()
+
+
 RUNNER = (
     MODEL_SETUP
+    + "\n\n"
+    + EVOLVED_CONTEXT_SETUP
     + r"""
 import json
 from pathlib import Path
@@ -84,6 +164,7 @@ from minisweagent.environments.local import LocalEnvironment, LocalEnvironmentCo
 task = Path(os.environ["MINISWE_TASK_PATH"]).read_text()
 config = get_config_from_spec(os.environ.get("MINISWE_CONFIG", "mini"))
 agent_kwargs = _filtered(config.get("agent"), AgentConfig.model_fields)
+_apply_evolved_context(agent_kwargs, "/installed-agent/miniswe-source")
 env_kwargs = _filtered(config.get("environment"), LocalEnvironmentConfig.model_fields)
 env_kwargs["cwd"] = os.environ.get("MINISWE_CWD") or os.getcwd()
 env_kwargs["timeout"] = int(os.environ.get("MINISWE_ENV_TIMEOUT", env_kwargs.get("timeout") or 30))
@@ -97,14 +178,19 @@ print(json.dumps(agent.run(task), default=str))
 ).strip()
 
 
-MINISWE_PREFLIGHT = r"""
+MINISWE_PREFLIGHT = (
+    EVOLVED_CONTEXT_SETUP
+    + "\n\n"
+    + r"""
 from minisweagent.agents.default import DefaultAgent
 from minisweagent.config import get_config_from_spec
 from minisweagent.environments.local import LocalEnvironment
 
 assert DefaultAgent and LocalEnvironment and get_config_from_spec
+_load_evolved_context("/installed-agent/miniswe-source")
 print("EVOLVE_PREFLIGHT: miniswe_import_ok")
-""".strip()
+"""
+).strip()
 
 
 MODEL_PREFLIGHT = (
@@ -221,20 +307,25 @@ class MiniSweSourceAgent(MiniSweAgent):
 
     def _runtime_evidence_command(self) -> str:
         mode = self._get_env("EVOLVE_CANDIDATE_SMOKE_MODE") or "normal"
-        payload = (
-            json.dumps(
-                {
-                    "schema_version": 1,
-                    "mode": mode,
-                    "frozen_sync": True,
-                    "miniswe_import": True,
-                    "model_path_init": mode != "container",
-                },
-                sort_keys=True,
-            )
-            + "\n"
+        payload = json.dumps(
+            {
+                "schema_version": 1,
+                "mode": mode,
+                "frozen_sync": True,
+                "miniswe_import": True,
+                "model_path_init": mode != "container",
+            },
+            sort_keys=True,
         )
-        script = f"from pathlib import Path; Path({RUNTIME_EVIDENCE_PATH!r}).write_text({payload!r})"
+        script = (
+            EVOLVED_CONTEXT_SETUP
+            + "\n"
+            + f"context, stats = _load_evolved_context({SOURCE_DIR!r})\n"
+            + f"payload = json.loads({payload!r})\n"
+            + "payload.update(stats)\n"
+            + "payload['context_chars'] = len(context)\n"
+            + f"Path({RUNTIME_EVIDENCE_PATH!r}).write_text(json.dumps(payload, sort_keys=True) + '\\n')"
+        )
         return f"mkdir -p /logs/agent; {VENV_PYTHON} -c {shlex.quote(script)}"
 
     def _host_uv_binary(self) -> Path | None:

--- a/templates/workspace/evolve_harbor_adapter/__init__.py
+++ b/templates/workspace/evolve_harbor_adapter/__init__.py
@@ -211,8 +211,8 @@ class MiniSweSourceAgent(MiniSweAgent):
     async def _runtime_phase(self, environment, command: str, code: str, *, env: dict[str, str]) -> None:
         try:
             await self.exec_as_agent(environment, command=command, env=env)
-        except Exception:
-            raise EvolveRuntimeInfrastructureError(f"EVOLVE_RUNTIME_INFRASTRUCTURE: {code}") from None
+        except Exception as error:
+            raise EvolveRuntimeInfrastructureError(f"EVOLVE_RUNTIME_INFRASTRUCTURE: {code}: {error}") from None
 
     def _preflight_command(self, marker: str, script: str) -> str:
         return (

--- a/templates/workspace/evolve_harbor_adapter/__init__.py
+++ b/templates/workspace/evolve_harbor_adapter/__init__.py
@@ -70,8 +70,88 @@ def build_model(config):
 """.strip()
 
 
+EVOLVED_CONTEXT_SETUP = r"""
+import json
+from pathlib import Path
+
+import yaml
+
+
+def _load_evolved_context(source_dir):
+    source_root = Path(source_dir)
+    skills = []
+    skills_dir = source_root / "skills"
+    if skills_dir.is_dir():
+        for skill_file in sorted(skills_dir.glob("*/SKILL.md")):
+            if skill_file.parent.name.startswith("_"):
+                continue
+            text = skill_file.read_text()
+            metadata = {}
+            if text.startswith("---"):
+                parts = text.split("---", 2)
+                if len(parts) == 3:
+                    metadata = yaml.safe_load(parts[1]) or {}
+                    if not isinstance(metadata, dict):
+                        raise ValueError(f"Skill frontmatter must be a mapping: {skill_file}")
+            skills.append(
+                {
+                    "name": str(metadata.get("name") or skill_file.parent.name),
+                    "description": str(metadata.get("description") or "").strip(),
+                    "path": skill_file,
+                }
+            )
+
+    memories = []
+    memory_dir = source_root / "memory"
+    if memory_dir.is_dir():
+        for memory_file in sorted(memory_dir.glob("*.jsonl")):
+            for line_number, line in enumerate(memory_file.read_text().splitlines(), 1):
+                if not line.strip():
+                    continue
+                entry = json.loads(line)
+                if not isinstance(entry, dict):
+                    raise ValueError(f"Memory entry must be an object: {memory_file}:{line_number}")
+                memories.append(entry)
+    memories = memories[-100:]
+
+    sections = []
+    if skills:
+        lines = [
+            "## Available Skills",
+            "",
+            "Reusable procedures are available below. Before a relevant task, use the bash tool to read the "
+            "referenced `SKILL.md` file and follow its full procedure.",
+        ]
+        for skill in skills:
+            description = f": {skill['description']}" if skill["description"] else ""
+            lines.append(f"- **{skill['name']}**{description} (file: `{skill['path']}`)")
+        sections.append("\n".join(lines))
+    if memories:
+        lines = [
+            "## Evolved Memory",
+            "",
+            "These are transferable observations retained from earlier task trajectories. Apply them only when "
+            "relevant to the current task.",
+        ]
+        lines.extend(f"- {json.dumps(entry, ensure_ascii=False, sort_keys=True)}" for entry in memories)
+        sections.append("\n".join(lines))
+    text = "\n\n".join(sections)
+    return text, {"skills_loaded": len(skills), "memories_loaded": len(memories)}
+
+
+def _apply_evolved_context(agent_kwargs, source_dir):
+    context, stats = _load_evolved_context(source_dir)
+    if context:
+        system_template = str(agent_kwargs.get("system_template") or "").rstrip()
+        agent_kwargs["system_template"] = f"{system_template}\n\n{context}\n"
+    return stats
+""".strip()
+
+
 RUNNER = (
     MODEL_SETUP
+    + "\n\n"
+    + EVOLVED_CONTEXT_SETUP
     + r"""
 import json
 from pathlib import Path
@@ -84,6 +164,7 @@ from minisweagent.environments.local import LocalEnvironment, LocalEnvironmentCo
 task = Path(os.environ["MINISWE_TASK_PATH"]).read_text()
 config = get_config_from_spec(os.environ.get("MINISWE_CONFIG", "mini"))
 agent_kwargs = _filtered(config.get("agent"), AgentConfig.model_fields)
+_apply_evolved_context(agent_kwargs, "/installed-agent/miniswe-source")
 env_kwargs = _filtered(config.get("environment"), LocalEnvironmentConfig.model_fields)
 env_kwargs["cwd"] = os.environ.get("MINISWE_CWD") or os.getcwd()
 env_kwargs["timeout"] = int(os.environ.get("MINISWE_ENV_TIMEOUT", env_kwargs.get("timeout") or 30))
@@ -97,14 +178,19 @@ print(json.dumps(agent.run(task), default=str))
 ).strip()
 
 
-MINISWE_PREFLIGHT = r"""
+MINISWE_PREFLIGHT = (
+    EVOLVED_CONTEXT_SETUP
+    + "\n\n"
+    + r"""
 from minisweagent.agents.default import DefaultAgent
 from minisweagent.config import get_config_from_spec
 from minisweagent.environments.local import LocalEnvironment
 
 assert DefaultAgent and LocalEnvironment and get_config_from_spec
+_load_evolved_context("/installed-agent/miniswe-source")
 print("EVOLVE_PREFLIGHT: miniswe_import_ok")
-""".strip()
+"""
+).strip()
 
 
 MODEL_PREFLIGHT = (
@@ -224,20 +310,25 @@ class MiniSweSourceAgent(MiniSweAgent):
 
     def _runtime_evidence_command(self) -> str:
         mode = self._get_env("EVOLVE_CANDIDATE_SMOKE_MODE") or "normal"
-        payload = (
-            json.dumps(
-                {
-                    "schema_version": 1,
-                    "mode": mode,
-                    "frozen_sync": True,
-                    "miniswe_import": True,
-                    "model_path_init": mode != "container",
-                },
-                sort_keys=True,
-            )
-            + "\n"
+        payload = json.dumps(
+            {
+                "schema_version": 1,
+                "mode": mode,
+                "frozen_sync": True,
+                "miniswe_import": True,
+                "model_path_init": mode != "container",
+            },
+            sort_keys=True,
         )
-        script = f"from pathlib import Path; Path({RUNTIME_EVIDENCE_PATH!r}).write_text({payload!r})"
+        script = (
+            EVOLVED_CONTEXT_SETUP
+            + "\n"
+            + f"context, stats = _load_evolved_context({SOURCE_DIR!r})\n"
+            + f"payload = json.loads({payload!r})\n"
+            + "payload.update(stats)\n"
+            + "payload['context_chars'] = len(context)\n"
+            + f"Path({RUNTIME_EVIDENCE_PATH!r}).write_text(json.dumps(payload, sort_keys=True) + '\\n')"
+        )
         return f"mkdir -p /logs/agent; {VENV_PYTHON} -c {shlex.quote(script)}"
 
     def _host_uv_binary(self) -> Path | None:

--- a/tests/test_aevolve_meta_agent.py
+++ b/tests/test_aevolve_meta_agent.py
@@ -84,6 +84,15 @@ def _case(tmp_path: Path):
     evidence = run_dir / "feedback" / "evidence"
     evidence.mkdir(parents=True)
     (evidence / "history.json").write_text(json.dumps([{"genid": "1"}]))
+    (evidence / "selected.md").write_text(
+        "# Selected execution evidence\n\n"
+        "Across failed tasks, the agent stopped after producing an approximation and did not verify exact output paths.\n"
+    )
+    (run_dir / "feedback" / "index.md").write_text(
+        "# Feedback Bundle\n\n"
+        "- [selected trace evidence](evidence/selected.md)\n"
+        "- [rollout and edit history](evidence/history.json)\n"
+    )
     workspace.mkdir(exist_ok=True)
     (workspace / "archive.jsonl").write_text('{"genid":"1","score":1}\n')
     _git(checkout, "init", "-q")
@@ -123,9 +132,16 @@ def test_aevolve_reproduces_recent_summary_draft_and_workspace_mutation_cycle(
         assert "infra-noise" not in prompt
         assert "A draft about verifying generated artifacts" in prompt
         assert "Current Skills (1)" in prompt and "- existing" in prompt
-        assert "You CAN modify `target/prompt.md`" in prompt
-        assert "target/memory" in prompt and "You CAN add or prune" not in prompt
+        assert "You CAN modify any file under `target/`" in prompt
+        assert "Runtime prompt/config: `target/prompt.md`" in prompt
+        assert "Skills evolution: enabled" in prompt
+        assert "Memory evolution: disabled" in prompt
+        assert "target/memory" in prompt
         assert "x" * 300 not in prompt
+        assert "Selected execution evidence" in prompt
+        assert "did not verify exact output paths" in prompt
+        assert "runs/gen-2/feedback/evidence/selected.md" in prompt
+        assert "runs/gen-2/trace_analyzer/evidence/" in prompt
         assert "Preserve the `{{ instruction }}` placeholder" in prompt
         (root / "target" / "prompt.md").write_text("Verify artifacts before finishing.\n\n{{ instruction }}\n")
         skill = root / "target" / "skills" / "artifact-verification"
@@ -175,3 +191,104 @@ def test_aevolve_runner_failure_keeps_drafts_and_usage(tmp_path: Path, monkeypat
     assert (checkout / "target" / "skills" / "_drafts" / "candidate.md").is_file()
     assert (run_dir / "meta_agent" / "output.txt").read_text() == "runner output"
     assert json.loads((run_dir / "meta_agent" / "usage.json").read_text()) == {"usd": 0.2}
+
+
+def test_aevolve_prompt_path_is_a_component_location_not_a_permission_boundary(tmp_path: Path) -> None:
+    module = _module()
+    checkout, _run_dir, ctx = _case(tmp_path)
+    ctx.config.update({"evolve_skills": False, "editable_roots": ["target"]})
+
+    prompt, _state = module.build_prompt(checkout, ctx)
+
+    assert "You CAN modify any file under `target/`" in prompt
+    assert "Runtime prompt/config: `target/prompt.md`" in prompt
+    assert "Skills evolution: disabled" in prompt
+    assert "Review draft skills" not in prompt
+    assert "Do not add standalone files to a disabled context layer" in prompt
+
+
+def test_aevolve_rejects_directory_as_prompt_path(tmp_path: Path) -> None:
+    module = _module()
+    checkout, _run_dir, ctx = _case(tmp_path)
+    ctx.config["prompt_path"] = "target"
+
+    with pytest.raises(ValueError, match="prompt_path must reference an existing file"):
+        module.build_prompt(checkout, ctx)
+
+
+def test_aevolve_bounds_inline_evidence_and_keeps_complete_path(tmp_path: Path) -> None:
+    module = _module()
+    checkout, run_dir, ctx = _case(tmp_path)
+    selected = run_dir / "feedback" / "evidence" / "selected.md"
+    selected.write_text("distinctive evidence prefix\n" + "z" * 2_000 + "\ndistinctive evidence suffix\n")
+    ctx.config["evidence_chars"] = 400
+
+    prompt, _state = module.build_prompt(checkout, ctx)
+
+    assert "distinctive evidence prefix" in prompt
+    assert "distinctive evidence suffix" not in prompt
+    assert "inline evidence truncated" in prompt
+    assert "runs/gen-2/feedback/" in prompt
+
+
+def test_aevolve_uses_operator_observation_when_feedback_bundle_is_missing(tmp_path: Path) -> None:
+    module = _module()
+    checkout, run_dir, ctx = _case(tmp_path)
+    (run_dir / "feedback" / "index.md").unlink()
+
+    prompt, _state = module.build_prompt(checkout, ctx, "fallback analyzer observation")
+
+    assert "fallback analyzer observation" in prompt
+
+
+def test_aevolve_trajectory_only_prompt_has_one_behavior_evidence_section_and_no_labels(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = _module()
+    checkout, run_dir, ctx = _case(tmp_path)
+    trace_evidence = run_dir / "trace_analyzer" / "evidence"
+    trace_evidence.mkdir(parents=True)
+    (trace_evidence / "manifest.json").write_text(
+        json.dumps(
+            {
+                "selected_variant": "trajectory_only",
+                "evidence_policy": "trajectory_only",
+                "ground_truth_exposed": False,
+                "cases": 1,
+            }
+        )
+    )
+    selected = (
+        "### Agent Behavior Analysis (this batch)\n\n"
+        "You can ONLY see the agent's actions. You do NOT have access to actual test results.\n\n"
+        "```json\n"
+        '[{"task_id":"task-current","signals":{"n_tool_calls":2},'
+        '"compressed_trajectory":"Commands: 2, Errors: 1, Submitted: false",'
+        '"judge_verdict":{"score":2,"category":"debug","outcome":"likely failed",'
+        '"failure_reason":"stopped after an error"}}]\n'
+        "```\n"
+    )
+    (run_dir / "feedback" / "evidence" / "selected.md").write_text(selected)
+    ctx.config["trajectory_only"] = True
+    monkeypatch.setattr(
+        module,
+        "_case_summaries",
+        lambda _ctx: (_ for _ in ()).throw(AssertionError("trajectory-only must not read labeled cases")),
+    )
+
+    prompt, state = module.build_prompt(checkout, ctx)
+
+    assert state["trajectory_only"] is True
+    assert state["tasks_analyzed"] == 1
+    assert prompt.count("### Agent Behavior Analysis (this batch)") == 1
+    assert "### Task Summaries" not in prompt
+    assert "Trace-Analyzer Feedback" not in prompt
+    assert "feedback/index.md" not in prompt
+    assert '"success":' not in prompt
+    assert '"reward":' not in prompt
+    assert '"score":2' in prompt
+    assert "all checks passed" not in prompt
+    assert "missing output artifact" not in prompt
+    assert "Raw trace evidence:" not in prompt
+    assert "runs/gen-2/" not in prompt
+    assert "do not search for evaluator labels or test feedback" in prompt

--- a/tests/test_aevolve_recipe.py
+++ b/tests/test_aevolve_recipe.py
@@ -19,6 +19,7 @@ def test_aevolve_recipe_initializes_builtin_codex_workspace_contract(tmp_path: P
     assert "agent: target.agent:HarborAgent" in config
     assert "variant: trajectory_only" in config
     assert "trajectory_only: true" in config
+    assert "expose_gate_data: false" in config
     assert "runner: harbor" in config
     assert "evolve_memory: false" in config
     assert "evolve_tools: false" in config

--- a/tests/test_aevolve_recipe.py
+++ b/tests/test_aevolve_recipe.py
@@ -17,7 +17,8 @@ def test_aevolve_recipe_initializes_builtin_codex_workspace_contract(tmp_path: P
     config = (workspace / "evolve.yaml").read_text()
     assert "seed: builtin-codex" in config
     assert "agent: target.agent:HarborAgent" in config
-    assert "variant: execution_records" in config
+    assert "variant: trajectory_only" in config
+    assert "trajectory_only: true" in config
     assert "runner: harbor" in config
     assert "evolve_memory: false" in config
     assert "evolve_tools: false" in config
@@ -27,3 +28,6 @@ def test_aevolve_recipe_initializes_builtin_codex_workspace_contract(tmp_path: P
     operator = (workspace / "operators" / "meta_agent.py").read_text()
     assert "A-Evolve Workspace Improvement" in operator
     assert "class AEvolveMetaAgent" in operator
+    analyzer = (workspace / "operators" / "trace_analyzer.py").read_text()
+    assert "source=library/trace_analyzer/trajectory_only.py" in analyzer
+    assert "class TrajectoryOnly" in analyzer

--- a/tests/test_ahe_meta_agent.py
+++ b/tests/test_ahe_meta_agent.py
@@ -35,6 +35,9 @@ def _case(tmp_path: Path, *, genid: str = "1", parent: str = "0"):
     source = checkout / "target/src/minisweagent/agents/default.py"
     source.parent.mkdir(parents=True)
     source.write_text("STEP_LIMIT = 10\n")
+    prompt = checkout / "target/src/minisweagent/config/mini.yaml"
+    prompt.parent.mkdir(parents=True)
+    prompt.write_text("agent:\n  system_template: helpful\n")
     (checkout / "evolve.yaml").write_text(
         "experiment:\n  id: ahe\n"
         "surface:\n  include:\n    - target/**\n  exclude: []\n"
@@ -130,6 +133,9 @@ def test_ahe_prompt_uses_official_decisions_and_required_manifest(tmp_path: Path
         "runs the target's `DefaultAgent` with the `mini` configuration",
         "Benchmark-specific configurations are inactive",
         "Do not refer to debuggers",
+        "You CAN modify any file under `target/`",
+        "Runtime prompt/config: `target/src/minisweagent/config/mini.yaml`",
+        "This method further restricts the current proposal to: `target`",
     ):
         assert required in prompt
     assert "OVERVIEW ROOT CAUSE" in prompt

--- a/tests/test_driver_lock.py
+++ b/tests/test_driver_lock.py
@@ -1,0 +1,25 @@
+import os
+from pathlib import Path
+
+import pytest
+from conftest import init_workspace
+
+from evolve.driver import RunOptions, run, workspace_run_lock
+
+
+def test_driver_rejects_a_second_run_for_the_same_workspace(tmp_path: Path) -> None:
+    workspace, _ = init_workspace(tmp_path)
+
+    with workspace_run_lock(workspace):
+        with pytest.raises(RuntimeError, match="another evolve run already owns workspace"):
+            run(RunOptions(workspace=workspace, max_generations=0))
+
+
+def test_stale_driver_lock_file_does_not_block_a_new_run(tmp_path: Path) -> None:
+    workspace, _ = init_workspace(tmp_path)
+    lock_path = workspace / "runs" / ".driver.lock"
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path.write_text("999999\n")
+
+    with workspace_run_lock(workspace):
+        assert lock_path.read_text() == f"{os.getpid()}\n"

--- a/tests/test_gepa_meta_agent.py
+++ b/tests/test_gepa_meta_agent.py
@@ -34,6 +34,7 @@ def _case(tmp_path: Path):
     skill.parent.mkdir(parents=True)
     (checkout / "target/prompt.md").write_text("Solve: {{ instruction }}\n")
     skill.write_text("Inspect, edit, test.\n")
+    (checkout / "program.md").write_text("protected\n")
     (checkout / "evolve.yaml").write_text(
         "experiment:\n  id: gepa\n"
         "surface:\n  include:\n    - target/**\n  exclude: []\n"
@@ -47,6 +48,33 @@ def _case(tmp_path: Path):
             {
                 "prompt": [{"Inputs": {"task_id": "a"}, "Feedback": {"outcome": "failed"}}],
                 "skill": [{"Inputs": {"task_id": "a"}, "Feedback": {"outcome": "failed"}}],
+            }
+        )
+    )
+    reflection = evidence / "reflection"
+    reflection.mkdir()
+    reflection.joinpath("00-prompt.json").write_text(
+        json.dumps([{"Inputs": {"task_id": "a"}, "Feedback": {"outcome": "failed"}}])
+    )
+    reflection.joinpath("01-skill.json").write_text(
+        json.dumps([{"Inputs": {"task_id": "a"}, "Feedback": {"outcome": "failed"}}])
+    )
+    evidence.joinpath("manifest.json").write_text(
+        json.dumps(
+            {
+                "selected_variant": "gepa",
+                "component_evidence": {
+                    "prompt": {
+                        "file": "reflection/00-prompt.json",
+                        "paths": ["target/prompt.md"],
+                        "records": 1,
+                    },
+                    "skill": {
+                        "file": "reflection/01-skill.json",
+                        "paths": ["target/skills/task-execution/SKILL.md"],
+                        "records": 1,
+                    },
+                },
             }
         )
     )
@@ -66,7 +94,9 @@ def _case(tmp_path: Path):
     return checkout, run_dir, ctx
 
 
-def test_gepa_meta_agent_edits_only_selected_component(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_gepa_meta_agent_reads_file_evidence_and_edits_live_target(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     module = _module()
     checkout, run_dir, ctx = _case(tmp_path)
 
@@ -75,8 +105,12 @@ def test_gepa_meta_agent_edits_only_selected_component(tmp_path: Path, monkeypat
         assert "`prompt`" in prompt
         assert "{{ instruction }}" in prompt
         assert "You CAN modify any file under `target/`" in prompt
-        assert "This method further restricts the current proposal to: `target/prompt.md`" in prompt
+        assert "This method does not impose a narrower per-proposal path scope." in prompt
         assert "Runtime prompt/config: `target/prompt.md`" in prompt
+        assert "/app/task/workspace/runs/gen-1/trace_analyzer/evidence/manifest.json" in prompt
+        assert "/app/task/workspace/runs/gen-1/trace_analyzer/evidence/reflection/00-prompt.json" in prompt
+        assert '"task_id": "a"' not in prompt
+        assert "Solve: {{ instruction }}" not in prompt
         (root / "target/prompt.md").write_text("Be systematic. Solve: {{ instruction }}\n")
         return SimpleNamespace(output="edited", usage={"usd": 0.1})
 
@@ -87,13 +121,12 @@ def test_gepa_meta_agent_edits_only_selected_component(tmp_path: Path, monkeypat
     proposal = json.loads((run_dir / "meta_agent/proposal.json").read_text())
     assert proposal["components"] == ["prompt"]
     assert proposal["example_counts"] == {"prompt": 1}
-    assert json.loads((run_dir / "meta_agent/component-scope-check.json").read_text()) == {
-        "ok": True,
-        "violations": [],
-    }
+    assert proposal["evidence_files"] == {"prompt": "runs/gen-1/trace_analyzer/evidence/reflection/00-prompt.json"}
 
 
-def test_gepa_meta_agent_rejects_changes_outside_component(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_gepa_meta_agent_allows_changes_outside_focus_within_target(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     module = _module()
     checkout, _run_dir, ctx = _case(tmp_path)
 
@@ -102,5 +135,21 @@ def test_gepa_meta_agent_rejects_changes_outside_component(tmp_path: Path, monke
         return SimpleNamespace(output="edited", usage={"usd": 0})
 
     monkeypatch.setattr(module, "run_agent", fake_run)
-    with pytest.raises(SystemExit, match="outside the selected component"):
+    result = module.GepaMetaAgent().run(checkout, "unused", ctx)
+
+    assert result.changed == ["target/skills/task-execution/SKILL.md"]
+
+
+def test_gepa_meta_agent_rejects_changes_outside_mutable_surface(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    module = _module()
+    checkout, _run_dir, ctx = _case(tmp_path)
+
+    def fake_run(root: Path, _prompt: str, _ctx: OperatorContext):
+        (root / "program.md").write_text("changed\n")
+        return SimpleNamespace(output="edited", usage={"usd": 0})
+
+    monkeypatch.setattr(module, "run_agent", fake_run)
+    with pytest.raises(SystemExit, match="outside the mutable surface"):
         module.GepaMetaAgent().run(checkout, "unused", ctx)

--- a/tests/test_gepa_meta_agent.py
+++ b/tests/test_gepa_meta_agent.py
@@ -74,6 +74,9 @@ def test_gepa_meta_agent_edits_only_selected_component(tmp_path: Path, monkeypat
         assert "assertion" not in prompt
         assert "`prompt`" in prompt
         assert "{{ instruction }}" in prompt
+        assert "You CAN modify any file under `target/`" in prompt
+        assert "This method further restricts the current proposal to: `target/prompt.md`" in prompt
+        assert "Runtime prompt/config: `target/prompt.md`" in prompt
         (root / "target/prompt.md").write_text("Be systematic. Solve: {{ instruction }}\n")
         return SimpleNamespace(output="edited", usage={"usd": 0.1})
 

--- a/tests/test_gepa_recipe.py
+++ b/tests/test_gepa_recipe.py
@@ -18,6 +18,7 @@ def test_gepa_recipe_initializes_all_native_operators(tmp_path: Path) -> None:
     assert "seed: builtin-codex" in config
     assert "variant: minibatch_improvement" in config
     assert "component_strategy: round_robin" in config
+    assert "expose_gate_data: false" in config
     assert "agent: target.agent:HarborAgent" in config
     assert "class ParetoSelect" in (workspace / "operators/select.py").read_text()
     assert "class GepaTraceAnalyzer" in (workspace / "operators/trace_analyzer.py").read_text()
@@ -25,3 +26,6 @@ def test_gepa_recipe_initializes_all_native_operators(tmp_path: Path) -> None:
     assert "class MinibatchImprovementValidate" in (workspace / "operators/validate.py").read_text()
     assert "class GepaRecord" in (workspace / "operators/record.py").read_text()
     assert (workspace / "library/gepa_support.py").is_file()
+    meta_agent = (workspace / "library/meta_agent/gepa.py").read_text()
+    assert "## Reflective dataset" not in meta_agent
+    assert "component_evidence" in meta_agent

--- a/tests/test_gepa_trace_analyzer.py
+++ b/tests/test_gepa_trace_analyzer.py
@@ -29,7 +29,11 @@ def test_gepa_trace_analyzer_builds_component_reflective_dataset(tmp_path: Path)
             "outcome": "failed",
             "instruction": "Fix A",
             "agent_messages": ["trying"],
-            "events": [{"type": "tool_call", "name": "exec"}],
+            "events": [{"type": "tool_call", "name": "legacy"}],
+            "trajectory_events": [
+                {"type": "agent_message", "message": "start"},
+                {"type": "tool_call", "name": "exec"},
+            ],
             "tool_calls": [{"name": "exec", "arguments": "pytest"}],
             "observations": ["failed"],
             "verifier_output": "assertion failed",
@@ -58,7 +62,18 @@ def test_gepa_trace_analyzer_builds_component_reflective_dataset(tmp_path: Path)
     assert len(dataset["prompt"]) == len(dataset["skill"]) == 1
     record = dataset["prompt"][0]
     assert record["Inputs"] == {"instruction": "Fix A", "task_id": "task-a"}
-    assert record["Generated Outputs"]["ordered_events"][0]["name"] == "exec"
+    assert record["Generated Outputs"]["ordered_events"] == [
+        {"message": "start", "type": "agent_message"},
+        {"name": "exec", "type": "tool_call"},
+    ]
     assert record["Feedback"]["verifier_output"] == "assertion failed"
     assert record["Scores (Higher is Better)"] == {"reward": 0.0}
+    manifest = json.loads((run_dir / "trace_analyzer/evidence/manifest.json").read_text())
+    assert manifest["component_evidence"] == {
+        "prompt": {"file": "reflection/00-prompt.json", "paths": ["target/prompt.md"], "records": 1},
+        "skill": {"file": "reflection/01-skill.json", "paths": ["target/skills/task/SKILL.md"], "records": 1},
+    }
+    prompt_records = json.loads((run_dir / "trace_analyzer/evidence/reflection/00-prompt.json").read_text())
+    assert prompt_records == dataset["prompt"]
+    assert "trace_analyzer/evidence/reflection/00-prompt.json" in result.artifacts
     assert result.summary["usable_cases"] == 1

--- a/tests/test_harbor_meta_agent.py
+++ b/tests/test_harbor_meta_agent.py
@@ -187,9 +187,11 @@ if not readonly:
     artifact.parent.mkdir(parents=True, exist_ok=True)
     workspace = source / "workspace"
     if not (workspace / ".git").exists():
-        raise SystemExit("workspace is missing Git history")
-    if not (workspace / "archive.jsonl").is_file():
-        raise SystemExit("workspace is missing archive evidence")
+        raise SystemExit("workspace is missing sanitized Git baseline")
+    if (workspace / "archive.jsonl").exists():
+        raise SystemExit("workspace exposes archive evidence")
+    if (workspace / "evaluator").exists():
+        raise SystemExit("workspace exposes evaluator data")
     if not (workspace / "runs" / "gen-1" / "trace_analyzer" / "evidence" / "raw_traces.jsonl").is_file():
         raise SystemExit("workspace is missing current trace evidence")
     shutil.copytree(workspace, artifact, symlinks=True)
@@ -340,6 +342,7 @@ def test_harbor_meta_agent_round_trips_target_and_writes_artifacts(
     assert "failure evidence" in prompt
     assert "/app/task/workspace" in prompt
     assert "remove generated virtual environments" in prompt
+    assert "gate/sealed evaluations are intentionally unavailable" in prompt
     assert "/app/candidate" not in prompt
     command = json.loads((meta_dir / "harbor" / "command.json").read_text())
     assert command[command.index("--artifact") + 1] == "/app/task/workspace"
@@ -607,19 +610,132 @@ def test_multi_root_install_rolls_back_when_second_replacement_fails(
         shutil.rmtree(bundle.staging, ignore_errors=True)
 
 
-def test_trajectory_only_bundle_omits_archive_and_run_evidence(tmp_path: Path) -> None:
+@pytest.mark.parametrize("trajectory_only", [None, False, True])
+def test_harbor_bundle_never_exposes_gate_or_sealed_data(tmp_path: Path, trajectory_only: bool | None) -> None:
     checkout, run_dir = _checkout(tmp_path)
+    evaluator = checkout / "evaluator"
+    evaluator.mkdir()
+    (evaluator / "splits.json").write_text(
+        json.dumps(
+            {
+                "tasks": {
+                    "train": ["train-task"],
+                    "gate": ["gate-secret-task"],
+                    "sealed": ["sealed-secret-task"],
+                }
+            }
+        )
+    )
+    _git(checkout, "add", "evaluator/splits.json")
+    _git(checkout, "commit", "-qm", "record private task partitions")
+    (checkout / ".evolve-eval-receipts.jsonl").write_text("private-receipt\n")
+    private_eval = checkout / "runs" / "evaluations" / "genesis"
+    private_eval.mkdir(parents=True)
+    (private_eval / "trajectory.json").write_text("gate-secret-task reward=1\n")
+    prior_evidence = checkout / "runs" / "gen-0" / "trace_analyzer" / "evidence"
+    prior_evidence.mkdir(parents=True)
+    (prior_evidence / "history.json").write_text('{"task_name":"train-task"}\n')
+    prior_gate = checkout / "runs" / "gen-0" / "gate"
+    prior_gate.mkdir()
+    (prior_gate / "result.json").write_text('{"gate-secret-task": 1}\n')
+    select = checkout / "runs" / "gen-1" / "select"
+    select.mkdir(parents=True)
+    (select / "pareto.json").write_text('{"gate-secret-task": 1}\n')
     runner = _harbor_runner_module()
     ctx = _ctx(checkout, run_dir)
-    ctx.config["trajectory_only"] = True
+    if trajectory_only is not None:
+        ctx.config["trajectory_only"] = trajectory_only
     surface = runner.load_surface_policy(checkout)
     bundle = runner._prepare_bundle(checkout, ctx, ["target"], surface)
     try:
         assert not (bundle.workspace / "archive.jsonl").exists()
-        assert not (bundle.workspace / "runs").exists()
+        assert not (bundle.workspace / ".evolve-eval-receipts.jsonl").exists()
+        assert not (bundle.workspace / "evaluator").exists()
+        assert not (bundle.workspace / "runs" / "evaluations").exists()
+        assert not (bundle.workspace / "runs" / "gen-1" / "select").exists()
+        assert not (bundle.workspace / "runs" / "gen-0" / "gate").exists()
+        assert (bundle.workspace / "runs" / "gen-0" / "trace_analyzer" / "evidence" / "history.json").is_file()
+        assert (bundle.workspace / "runs" / "gen-1" / "trace_analyzer" / "evidence" / "raw_traces.jsonl").is_file()
         assert (bundle.workspace / "target" / "agent.py").is_file()
+        assert _git(bundle.workspace, "status", "--short") == ""
+        assert _git(bundle.workspace, "log", "--all", "--", "evaluator/splits.json") == ""
+        assert "evaluator/splits.json" not in _git(bundle.workspace, "rev-list", "--all", "--objects")
+        visible = "\n".join(
+            path.read_text(errors="ignore")
+            for path in bundle.workspace.rglob("*")
+            if path.is_file() and ".git" not in path.relative_to(bundle.workspace).parts
+        )
+        assert "gate-secret-task" not in visible
+        assert "sealed-secret-task" not in visible
     finally:
         shutil.rmtree(bundle.staging, ignore_errors=True)
+
+
+@pytest.mark.parametrize("leak_source", ["prompt", "train-evidence"])
+def test_harbor_bundle_rejects_private_task_identifiers(tmp_path: Path, leak_source: str) -> None:
+    checkout, run_dir = _checkout(tmp_path)
+    evaluator = checkout / "evaluator"
+    evaluator.mkdir()
+    (evaluator / "splits.json").write_text(
+        json.dumps({"tasks": {"train": ["train-task"], "gate": ["gate-secret-task"], "sealed": []}})
+    )
+    prompt = "analyze gate-secret-task" if leak_source == "prompt" else "safe train evidence"
+    if leak_source == "train-evidence":
+        (run_dir / "trace_analyzer" / "evidence" / "raw_traces.jsonl").write_text('{"task_name":"gate-secret-task"}\n')
+    runner = _harbor_runner_module()
+    surface = runner.load_surface_policy(checkout)
+
+    with pytest.raises(RuntimeError, match="private gate/sealed task identifier"):
+        runner._prepare_bundle(
+            checkout,
+            _ctx(checkout, run_dir),
+            ["target"],
+            surface,
+            prompt=prompt,
+        )
+
+
+def test_harbor_bundle_exposes_gate_data_only_when_enabled(tmp_path: Path) -> None:
+    checkout, run_dir = _checkout(tmp_path)
+    evaluator = checkout / "evaluator"
+    evaluator.mkdir()
+    (evaluator / "splits.json").write_text(
+        json.dumps({"tasks": {"train": ["train-task"], "gate": ["gate-task"], "sealed": ["sealed-task"]}})
+    )
+    _git(checkout, "add", "evaluator/splits.json")
+    _git(checkout, "commit", "-qm", "record task partitions")
+    (checkout / ".evolve-eval-receipts.jsonl").write_text("receipt\n")
+    evaluation = checkout / "runs" / "evaluations" / "genesis"
+    evaluation.mkdir(parents=True)
+    (evaluation / "trajectory.json").write_text("gate-task reward=1\n")
+    ctx = _ctx(checkout, run_dir)
+    ctx.config["expose_gate_data"] = True
+    runner = _harbor_runner_module()
+    surface = runner.load_surface_policy(checkout)
+    bundle = runner._prepare_bundle(checkout, ctx, ["target"], surface, prompt="analyze gate-task")
+    try:
+        assert (bundle.workspace / "archive.jsonl").is_file()
+        assert (bundle.workspace / ".evolve-eval-receipts.jsonl").is_file()
+        assert (bundle.workspace / "evaluator" / "splits.json").is_file()
+        assert (bundle.workspace / "runs" / "evaluations" / "genesis" / "trajectory.json").is_file()
+        assert _git(bundle.workspace, "log", "--all", "--", "evaluator/splits.json")
+    finally:
+        shutil.rmtree(bundle.staging, ignore_errors=True)
+
+
+def test_harbor_bundle_rejects_non_boolean_gate_visibility(tmp_path: Path) -> None:
+    checkout, run_dir = _checkout(tmp_path)
+    ctx = _ctx(checkout, run_dir)
+    ctx.config["expose_gate_data"] = "false"
+    runner = _harbor_runner_module()
+
+    with pytest.raises(ValueError, match="expose_gate_data must be true or false"):
+        runner._prepare_bundle(
+            checkout,
+            ctx,
+            ["target"],
+            runner.load_surface_policy(checkout),
+        )
 
 
 def test_harbor_trial_exception_does_not_modify_target(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_harbor_meta_agent.py
+++ b/tests/test_harbor_meta_agent.py
@@ -607,6 +607,21 @@ def test_multi_root_install_rolls_back_when_second_replacement_fails(
         shutil.rmtree(bundle.staging, ignore_errors=True)
 
 
+def test_trajectory_only_bundle_omits_archive_and_run_evidence(tmp_path: Path) -> None:
+    checkout, run_dir = _checkout(tmp_path)
+    runner = _harbor_runner_module()
+    ctx = _ctx(checkout, run_dir)
+    ctx.config["trajectory_only"] = True
+    surface = runner.load_surface_policy(checkout)
+    bundle = runner._prepare_bundle(checkout, ctx, ["target"], surface)
+    try:
+        assert not (bundle.workspace / "archive.jsonl").exists()
+        assert not (bundle.workspace / "runs").exists()
+        assert (bundle.workspace / "target" / "agent.py").is_file()
+    finally:
+        shutil.rmtree(bundle.staging, ignore_errors=True)
+
+
 def test_harbor_trial_exception_does_not_modify_target(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     checkout, run_dir = _checkout(tmp_path)
     before = {

--- a/tests/test_host_runtime.py
+++ b/tests/test_host_runtime.py
@@ -28,6 +28,7 @@ def test_uv_run_uses_locked_workspace_and_cleans_python_environment(tmp_path: Pa
         "PYTHONHOME": "/wrong",
         "VIRTUAL_ENV": "/other",
         "OPENAI_API_KEY": "secret",
+        "TMPDIR": "/tmp/custom",
     }
 
     command, env = uv_run(tmp_path, "harbor", "run", env=source)
@@ -35,6 +36,7 @@ def test_uv_run_uses_locked_workspace_and_cleans_python_environment(tmp_path: Pa
     assert command == [str(uv), "run", "--project", str(tmp_path.resolve()), "--frozen", "harbor", "run"]
     assert not {"PYTHONPATH", "PYTHONHOME", "VIRTUAL_ENV"} & env.keys()
     assert env["OPENAI_API_KEY"] == "secret"
+    assert env["TMPDIR"] == "/tmp/custom"
     assert source["PYTHONPATH"] == "/unsafe"
 
 
@@ -42,6 +44,16 @@ def test_uv_executable_falls_back_to_path(tmp_path: Path) -> None:
     uv = _executable(tmp_path / "uv")
 
     assert uv_executable({"PATH": str(tmp_path)}) == str(uv)
+
+
+def test_uv_run_does_not_redirect_temp_root_into_workspace(tmp_path: Path) -> None:
+    _project(tmp_path)
+    uv = _executable(tmp_path / "uv")
+
+    _command, env = uv_run(tmp_path, "python", env={"EVOLVE_UV_BINARY": str(uv)})
+
+    assert "TMPDIR" not in env
+    assert not (tmp_path / "runs" / ".tmp").exists()
 
 
 def test_uv_run_reports_missing_runtime_inputs(tmp_path: Path) -> None:

--- a/tests/test_hyperagents_harbor_recipe.py
+++ b/tests/test_hyperagents_harbor_recipe.py
@@ -21,6 +21,7 @@ def test_hyperagents_recipe_initializes_broad_harbor_bundle(tmp_path: Path) -> N
     config = (workspace / "evolve.yaml").read_text()
     assert "variant: hyperagents" in config
     assert "runner: harbor" in config
+    assert "expose_gate_data: true" in config
     assert "agent: evolve_harbor_agent:FileTaskMiniSweAgent" in config
     assert "editable_roots:" in config
     assert "- target" in config and "- operators" in config

--- a/tests/test_hyperagents_meta_agent.py
+++ b/tests/test_hyperagents_meta_agent.py
@@ -44,6 +44,7 @@ def _checkout(tmp_path: Path) -> tuple[Path, Path]:
     (checkout / "target").mkdir(parents=True)
     (checkout / "operators").mkdir()
     (checkout / "target" / "agent.py").write_text("print('parent')\n")
+    (checkout / "target" / "prompt.md").write_text("Solve carefully.\n")
     (checkout / "operators" / "meta_agent.py").write_text("# parent mutation operator\n")
     (checkout / "evolve.yaml").write_text((workspace / "evolve.yaml").read_text())
     _git(checkout, "init", "-q")
@@ -107,6 +108,11 @@ def test_hyperagents_prompt_points_to_evolvable_codebase_and_prior_artifacts(tmp
     assert "`operators/**` remains editable" in prompt
     assert "cosmetic target edits" in prompt
     assert "You are editing the MiniSWE source checkout under target/." not in prompt
+    assert "You CAN modify any file under `target/`" in prompt
+    assert "You CAN modify any file under `operators/`" in prompt
+    assert "Runtime prompt/config: `target/prompt.md`" in prompt
+    assert "Reusable skills: not configured or detected" in prompt
+    assert "This method does not impose a narrower per-proposal path scope" in prompt
 
 
 def test_hyperagents_prompt_bounds_inline_evidence(tmp_path: Path) -> None:

--- a/tests/test_m1_evaluator_invariants.py
+++ b/tests/test_m1_evaluator_invariants.py
@@ -22,7 +22,6 @@ from evolve.evaluation.execution import (
 )
 from evolve.evaluation.identity import effective_task_set_identity
 from evolve.frozen.interfaces import ArchiveView
-from evolve.host_runtime import workspace_temp_dir
 from evolve.runtime import OwnedResult
 from evolve.uv_runtime import CandidateRuntimeResult, RuntimeMount
 
@@ -30,29 +29,6 @@ from evolve.uv_runtime import CandidateRuntimeResult, RuntimeMount
 def make_eval_script(path: Path, body: str) -> None:
     path.write_text(body)
     path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
-
-
-def test_evaluation_temp_root_defaults_to_workspace_volume(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.delenv("EVOLVE_TMPDIR", raising=False)
-    workspace = tmp_path / "workspace"
-
-    root = workspace_temp_dir(workspace)
-
-    assert root == workspace / "runs" / ".tmp"
-    assert root.is_dir()
-
-
-def test_evaluation_temp_root_accepts_configured_relative_path(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    workspace = tmp_path / "workspace"
-    monkeypatch.setenv("EVOLVE_TMPDIR", "scratch")
-
-    assert workspace_temp_dir(workspace) == workspace / "scratch"
 
 
 def configure_outcome_evaluator(
@@ -167,7 +143,6 @@ def test_eval_script_receives_persistent_workspace_uv_cache(tmp_path: Path) -> N
         "set -eu\n"
         'mkdir -p "$EVOLVE_RUN_DIR"\n'
         'printf "%s\\n" "$EVOLVE_UV_CACHE_DIR" > cache-path\n'
-        'printf "%s\\n" "$TMPDIR" > tmp-path\n'
         'printf "complete\\n" > "$EVOLVE_RUN_DIR/status"\n'
         'printf "1.0\\n" > "$EVOLVE_RUN_DIR/score"\n',
     )
@@ -188,7 +163,6 @@ def test_eval_script_receives_persistent_workspace_uv_cache(tmp_path: Path) -> N
     expected = workspace / "runs" / "runtime" / "uv-cache"
     assert (checkout / "cache-path").read_text() == f"{expected}\n"
     assert expected.is_dir()
-    assert (checkout / "tmp-path").read_text() == f"{workspace / 'runs' / '.tmp'}\n"
 
 
 def test_eval_script_preserves_explicit_shared_uv_cache(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_m7_harbor_rollout.py
+++ b/tests/test_m7_harbor_rollout.py
@@ -3,11 +3,12 @@ import json
 import random
 from pathlib import Path
 
+import pytest
 from conftest import init_workspace
 
 from evolve.feedback import write_feedback_bundle
 from evolve.frozen.interfaces import OperatorContext
-from evolve.trace_analysis import VARIANTS, write_evidence_bundle
+from evolve.trace_analysis import VARIANTS, _trajectory_only_cases, write_evidence_bundle
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -87,6 +88,13 @@ def test_harbor_rollout_distinguishes_task_agent_and_infra_failures(tmp_path: Pa
         exception_type="AgentTimeoutError",
         exception_message="Agent execution timed out",
     )
+    _write_trial(
+        jobs,
+        name="runtime-infrastructure",
+        reward=None,
+        exception_type="EvolveRuntimeInfrastructureError",
+        exception_message="external dependency sync failed",
+    )
 
     cases = module.collect_cases(jobs)
     by_name = {case["trial_name"]: case for case in cases}
@@ -96,6 +104,7 @@ def test_harbor_rollout_distinguishes_task_agent_and_infra_failures(tmp_path: Pa
     assert by_name["task-passed"]["outcome"] == "passed"
     assert by_name["verifier-timeout"]["outcome"] == "infra_error"
     assert by_name["agent-timeout"]["outcome"] == "agent_error"
+    assert by_name["runtime-infrastructure"]["outcome"] == "infra_error"
     assert by_name["task-failed"]["instruction"] == "Fix task task-failed."
     assert by_name["task-failed"]["tool_calls"][0]["name"] == "exec"
     assert "missing output" in by_name["task-failed"]["observations"][0]
@@ -104,6 +113,24 @@ def test_harbor_rollout_distinguishes_task_agent_and_infra_failures(tmp_path: Pa
     assert "must-not-leak" not in by_name["task-failed"]["verifier_output"]
     assert "[REDACTED]" in by_name["task-failed"]["verifier_output"]
     assert "json-secret" not in module._redact('{"OPENAI_API_KEY":"json-secret"}')
+
+
+def test_harbor_rollout_rejects_evidence_when_every_case_is_infrastructure_failure(tmp_path: Path) -> None:
+    module = _harbor_rollout_module()
+    harbor_log = tmp_path / "harbor.log"
+
+    with pytest.raises(SystemExit, match="only infrastructure failures"):
+        module.require_usable_cases(
+            [{"outcome": "infra_error"}, {"outcome": "incomplete"}],
+            returncode=1,
+            harbor_log=harbor_log,
+        )
+
+    module.require_usable_cases(
+        [{"outcome": "infra_error"}, {"outcome": "failed"}],
+        returncode=1,
+        harbor_log=harbor_log,
+    )
 
 
 def test_harbor_rollout_defaults_jobs_to_workspace_runs(tmp_path: Path, monkeypatch) -> None:
@@ -190,6 +217,8 @@ def test_harbor_rollout_bounds_codex_session_events_to_the_latest_trace_window(t
     assert len(case["events"]) == 32
     assert case["events"][0]["message"] == "message-68"
     assert case["events"][-1]["message"] == "message-99"
+    assert len(case["trajectory_events"]) == 100
+    assert case["trajectory_events"][0]["message"] == "message-0"
 
 
 def test_harbor_rollout_bounds_trajectory_events_to_the_latest_trace_window(tmp_path: Path) -> None:
@@ -204,6 +233,8 @@ def test_harbor_rollout_bounds_trajectory_events_to_the_latest_trace_window(tmp_
     assert len(case["events"]) == 32
     assert case["events"][0]["message"] == "message-68"
     assert case["events"][-1]["message"] == "message-99"
+    assert len(case["trajectory_events"]) == 100
+    assert case["trajectory_events"][0]["message"] == "message-0"
 
 
 def test_feedback_bundle_exposes_current_rollout_to_mutator(tmp_path: Path) -> None:
@@ -236,8 +267,13 @@ def test_trace_analyzer_variants_share_raw_harbor_facts(tmp_path: Path) -> None:
             variant=variant,
             max_chars=100_000,
         )
-        assert f"Variant: {variant}" in selected
-        assert "trace_analyzer/evidence/raw_traces.jsonl" in artifacts
+        if variant == "trajectory_only":
+            assert "Agent Behavior Analysis" in selected
+            assert "trace_analyzer/evidence/raw_traces.jsonl" not in artifacts
+            assert "trace_analyzer/evidence/trajectory_only.json" in artifacts
+        else:
+            assert f"Variant: {variant}" in selected
+            assert "trace_analyzer/evidence/raw_traces.jsonl" in artifacts
         assert (run_dir / "trace_analyzer" / "evidence" / "manifest.json").is_file()
 
     patterns = json.loads(
@@ -249,6 +285,107 @@ def test_trace_analyzer_variants_share_raw_harbor_facts(tmp_path: Path) -> None:
         (tmp_path / "failure_patterns" / "trace_analyzer" / "evidence" / "passing_behaviors.json").read_text()
     )
     assert passing[0]["task_name"] == "harbor/passing"
+
+
+def test_trajectory_only_matches_aevolve_behavior_only_evidence(tmp_path: Path) -> None:
+    cases = [
+        {
+            "task_name": "terminal/task-a",
+            "outcome": "failed",
+            "reward": 0,
+            "verifier_output": "secret ground-truth failure",
+            "instruction": "Do a benchmark-specific thing",
+            "events": [
+                {
+                    "source": "agent",
+                    "message": "",
+                    "tool_calls": [
+                        {
+                            "name": "bash",
+                            "arguments": json.dumps({"command": "pytest -q"}),
+                        }
+                    ],
+                    "observations": ["ERROR: one test failed"],
+                },
+                {
+                    "source": "agent",
+                    "message": "finished",
+                    "tool_calls": [
+                        {
+                            "name": "bash",
+                            "arguments": json.dumps({"command": "git diff"}),
+                        }
+                    ],
+                    "observations": ["diff output"],
+                },
+            ],
+        }
+    ]
+
+    selected, artifacts = write_evidence_bundle(
+        tmp_path,
+        cases,
+        variant="trajectory_only",
+        max_chars=100_000,
+        judge_verdicts=[
+            {
+                "score": 2,
+                "category": "software-engineering",
+                "outcome": "Tests still failed.",
+                "failure_reason": "The agent stopped after the first failing test run.",
+            }
+        ],
+    )
+
+    evidence = tmp_path / "trace_analyzer" / "evidence"
+    records = json.loads((evidence / "trajectory_only.json").read_text())
+    manifest = json.loads((evidence / "manifest.json").read_text())
+    assert records[0]["task_id"] == "terminal/task-a"
+    assert records[0]["signals"]["n_turns"] == 2
+    assert records[0]["signals"]["n_tool_calls"] == 2
+    assert records[0]["signals"]["n_errors"] == 1
+    assert records[0]["judge_verdict"]["score"] == 2
+    assert records[0]["judge_verdict"]["failure_reason"].startswith("The agent stopped")
+    assert "[start] bash(pytest -q)" in records[0]["compressed_trajectory"]
+    assert "ERROR: one test failed" in records[0]["compressed_trajectory"]
+    assert "secret ground-truth failure" not in selected
+    assert "Do a benchmark-specific thing" not in selected
+    assert "reward" not in selected
+    assert manifest["ground_truth_exposed"] is False
+    assert not (evidence / "raw_traces.jsonl").exists()
+    assert artifacts == [
+        "trace_analyzer/evidence/manifest.json",
+        "trace_analyzer/evidence/trajectory_only.json",
+        "trace_analyzer/evidence/selected.md",
+    ]
+
+
+def test_trajectory_only_follows_recent_parent_lineage(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    run_dir = workspace / "runs" / "gen-2"
+    prior = workspace / "runs" / "gen-1" / "rollout"
+    prior.mkdir(parents=True)
+    prior_cases = [{"task_name": "prior-a"}, {"task_name": "prior-b"}]
+    (prior / "cases.json").write_text(json.dumps(prior_cases))
+    workspace.mkdir(exist_ok=True)
+    (workspace / "archive.jsonl").write_text(
+        json.dumps({"genid": "0", "parent": None}) + "\n" + json.dumps({"genid": "1", "parent": "0"}) + "\n"
+    )
+    ctx = OperatorContext(
+        workspace=workspace,
+        checkout=workspace,
+        run_dir=run_dir,
+        genid="2",
+        parent="1",
+        round=None,
+        fan_out=1,
+        config={"history_cycles": 2, "max_observations": 3},
+        rng=random.Random(0),
+    )
+
+    combined = _trajectory_only_cases(ctx, [{"task_name": "current-a"}, {"task_name": "current-b"}])
+
+    assert [case["task_name"] for case in combined] == ["prior-b", "current-a", "current-b"]
 
 
 def test_feedback_bundle_copies_selected_evidence_and_history(tmp_path: Path) -> None:

--- a/tests/test_m8_dataset_splits.py
+++ b/tests/test_m8_dataset_splits.py
@@ -197,7 +197,7 @@ def test_harbor_rollout_uses_only_frozen_train_task_names(tmp_path: Path, monkey
         {
             "type": "bind",
             "source": str(tmp_path / "uv-cache"),
-            "target": "/installed-agent/uv-cache",
+            "target": "/opt/evolve/uv/cache",
         },
         {
             "type": "bind",
@@ -208,6 +208,7 @@ def test_harbor_rollout_uses_only_frozen_train_task_names(tmp_path: Path, monkey
     assert captured.count("--mounts") == 1
     assert not set(included) & set(manifest["tasks"]["gate"] + manifest["tasks"]["sealed"])
     assert ("--ae", f"EVOLVE_CANDIDATE_SOURCE={checkout / 'target'}") in zip(captured, captured[1:], strict=False)
+    assert ("--ae", "UV_CACHE_DIR=/opt/evolve/uv/cache") in zip(captured, captured[1:], strict=False)
     assert ("--ae", "UV_PYTHON_INSTALL_DIR=/installed-agent/uv-python") in zip(captured, captured[1:], strict=False)
     assert ("--ae", "UV_OFFLINE=1") in zip(captured, captured[1:], strict=False)
     assert ("--ae", "UV_PYTHON=3.12") in zip(captured, captured[1:], strict=False)
@@ -230,8 +231,28 @@ def test_harbor_rollout_exact_task_replay_is_limited_to_frozen_train_split(tmp_p
     selected = module._select_train_tasks(tmp_path / "splits.json", "dataset", 1, ["train-c", "train-a"])
 
     assert selected == ["train-c", "train-a"]
+    assert module._select_train_tasks(
+        tmp_path / "splits.json",
+        "dataset",
+        1,
+        ["terminal-bench/train-c", "terminal-bench/train-a"],
+    ) == ["train-c", "train-a"]
     with pytest.raises(ValueError, match="frozen train split"):
         module._select_train_tasks(tmp_path / "splits.json", "dataset", 1, ["gate-a"])
+    with pytest.raises(ValueError, match="frozen train split"):
+        module._select_train_tasks(
+            tmp_path / "splits.json",
+            "dataset",
+            1,
+            ["terminal-bench/gate-a"],
+        )
+    with pytest.raises(ValueError, match="duplicates"):
+        module._select_train_tasks(
+            tmp_path / "splits.json",
+            "dataset",
+            1,
+            ["train-c", "terminal-bench/train-c"],
+        )
 
 
 def test_harbor_rollout_can_shuffle_train_minibatches_by_generation(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_m9_ahe_recipe.py
+++ b/tests/test_m9_ahe_recipe.py
@@ -56,6 +56,7 @@ def test_ahe_recipe_initializes_harbor_miniswe_composition(tmp_path: Path) -> No
     config = (workspace / "evolve.yaml").read_text()
     assert "variant: ahe" in config
     assert "runner: harbor" in config
+    assert "expose_gate_data: true" in config
     assert "agent: evolve_harbor_agent:FileTaskMiniSweAgent" in config
     assert "editable_roots:" in config
     operators = operator_blocks(workspace)

--- a/tests/test_miniswe_harbor_wrapper.py
+++ b/tests/test_miniswe_harbor_wrapper.py
@@ -1,5 +1,6 @@
 import asyncio
 import importlib.util
+import json
 import os
 import sys
 import types
@@ -192,6 +193,72 @@ def test_miniswe_wrapper_reuses_model_setup_for_runner_and_preflight(adapter_pat
     assert module.MODEL_PREFLIGHT.startswith(module.MODEL_SETUP)
     assert "model = build_model(config)" in module.RUNNER
     assert "build_model(config)" in module.MODEL_PREFLIGHT
+    compile(module.RUNNER, "<miniswe-runner>", "exec")
+    compile(module.MINISWE_PREFLIGHT, "<miniswe-preflight>", "exec")
+
+
+def test_miniswe_wrapper_loads_evolved_skills_and_memory_into_system_prompt(
+    adapter_path: Path,
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    _install_fake_harbor(monkeypatch)
+    module = _load(adapter_path)
+    source = tmp_path / "candidate"
+    skill = source / "skills" / "artifact-verification" / "SKILL.md"
+    skill.parent.mkdir(parents=True)
+    skill.write_text(
+        "---\n"
+        "name: artifact-verification\n"
+        "description: Verify generated artifacts before submitting\n"
+        "---\n\n"
+        "Check the exact output path and inspect the resulting file.\n"
+    )
+    draft = source / "skills" / "_drafts" / "SKILL.md"
+    draft.parent.mkdir()
+    draft.write_text("---\nname: ignored-draft\ndescription: not runtime context\n---\n")
+    memory = source / "memory" / "semantic.jsonl"
+    memory.parent.mkdir()
+    memory.write_text(
+        '{"insight":"Inspect exact output paths before submission","source":"trajectory"}\n'
+        '{"insight":"Run the task-specific verifier when available","source":"trajectory"}\n'
+    )
+    namespace = {}
+    exec(module.EVOLVED_CONTEXT_SETUP, namespace)
+
+    context, stats = namespace["_load_evolved_context"](source)
+    agent_kwargs = {"system_template": "Base MiniSwe system prompt."}
+    applied_stats = namespace["_apply_evolved_context"](agent_kwargs, source)
+
+    assert stats == {"skills_loaded": 1, "memories_loaded": 2}
+    assert applied_stats == stats
+    assert "## Available Skills" in context
+    assert "**artifact-verification**: Verify generated artifacts before submitting" in context
+    assert str(skill) in context
+    assert "ignored-draft" not in context
+    assert "## Evolved Memory" in context
+    assert "Inspect exact output paths before submission" in context
+    assert "Run the task-specific verifier when available" in context
+    assert agent_kwargs["system_template"].startswith("Base MiniSwe system prompt.")
+    assert context in agent_kwargs["system_template"]
+    assert '_apply_evolved_context(agent_kwargs, "/installed-agent/miniswe-source")' in module.RUNNER
+
+
+def test_miniswe_wrapper_rejects_invalid_evolved_memory(
+    adapter_path: Path,
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    _install_fake_harbor(monkeypatch)
+    module = _load(adapter_path)
+    memory = tmp_path / "candidate" / "memory" / "semantic.jsonl"
+    memory.parent.mkdir(parents=True)
+    memory.write_text("not-json\n")
+    namespace = {}
+    exec(module.EVOLVED_CONTEXT_SETUP, namespace)
+
+    with pytest.raises(json.JSONDecodeError):
+        namespace["_load_evolved_context"](tmp_path / "candidate")
 
 
 def test_miniswe_wrapper_subclasses_harbor_miniswe_and_installs_candidate_source(
@@ -269,6 +336,9 @@ def test_miniswe_wrapper_subclasses_harbor_miniswe_and_installs_candidate_source
     assert '"frozen_sync": true' in environment.commands[evidence_index]
     assert '"miniswe_import": true' in environment.commands[evidence_index]
     assert '"model_path_init": true' in environment.commands[evidence_index]
+    assert "skills_loaded" in environment.commands[evidence_index]
+    assert "memories_loaded" in environment.commands[evidence_index]
+    assert "context_chars" in environment.commands[evidence_index]
     proxy_names = {
         "HTTP_PROXY",
         "HTTPS_PROXY",

--- a/tests/test_miniswe_harbor_wrapper.py
+++ b/tests/test_miniswe_harbor_wrapper.py
@@ -425,7 +425,7 @@ def test_miniswe_external_dependency_sync_is_infrastructure_owned(tmp_path: Path
     with pytest.raises(module.EvolveRuntimeInfrastructureError) as raised:
         asyncio.run(module.MiniSweSourceAgent().install(Environment()))
 
-    assert str(raised.value) == "EVOLVE_RUNTIME_INFRASTRUCTURE: external_dependency_sync_failed"
+    assert str(raised.value) == ("EVOLVE_RUNTIME_INFRASTRUCTURE: external_dependency_sync_failed: offline cache miss")
 
 
 def test_miniswe_offline_runtime_never_downloads_uv(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_phase_e_recipes.py
+++ b/tests/test_phase_e_recipes.py
@@ -4,7 +4,7 @@ from evolve.config import RECIPE_NAMES, load_config
 
 ROOT = Path(__file__).resolve().parents[1]
 RECIPES = ROOT / "recipes"
-REAL_RECIPES = {"aevolve", "ahe", "gepa", "hill_climb", "hyperagents"}
+REAL_RECIPES = {"aevolve", "aevolve_tbench_bridge", "ahe", "gepa", "hill_climb", "hyperagents"}
 UV_SOURCE_RECIPES = {"ahe", "hill_climb", "hyperagents"}
 SMOKE_RECIPES = {"hill_climb-smoke", "hyperagents-smoke"}
 
@@ -52,6 +52,7 @@ def test_real_recipes_use_harbor_and_method_meta_agent() -> None:
             assert "rollout: {variant: harbor" in config
             assert "trace_analyzer: {variant: trajectory_only" in config
             assert "trajectory_only: true" in config
+            assert "expose_gate_data: false" in config
             assert "variant: aevolve" in config
             assert "runner: harbor" in config
             assert "agent: codex" in config
@@ -61,6 +62,28 @@ def test_real_recipes_use_harbor_and_method_meta_agent() -> None:
             assert "evolve_memory: false" in config
             assert "evolve_tools: false" in config
             assert "agent: target.agent:HarborAgent" in config
+        elif name == "aevolve_tbench_bridge":
+            parsed = _parsed_config(name)
+            evaluator = parsed["evaluator"]
+            assert isinstance(evaluator, dict)
+            assert "max_generations: 10" in config
+            assert "seed: builtin-codex" in config
+            assert "harbor_agent: miniswe-source" in config
+            assert "rollout:\n    variant: harbor" in config
+            assert "variant: trajectory_only" in config
+            assert "trajectory_only: true" in config
+            assert "expose_gate_data: false" in config
+            assert "variant: aevolve" in config
+            assert "runner: harbor" in config
+            assert "agent: codex" in config
+            assert "editable_roots: [target]" in config
+            assert "evolve_prompts: true" in config
+            assert "evolve_skills: true" in config
+            assert "evolve_memory: true" in config
+            assert "evolve_tools: false" in config
+            assert "agent: evolve_harbor_adapter:MiniSweSourceAgent" in config
+            assert evaluator["candidate_runtime"] == {"variant": "uv", "project": "target", "python": "3.12"}
+            assert evaluator["max_retries"] == 15
         elif name == "gepa":
             assert "dataset: swe-bench-lite" in config
             assert "seed: builtin-codex" in config
@@ -68,6 +91,7 @@ def test_real_recipes_use_harbor_and_method_meta_agent() -> None:
             assert "rollout: {variant: harbor" in config
             assert "task_sampling: generation_shuffle" in config
             assert "variant: gepa" in config
+            assert "expose_gate_data: false" in config
             assert "variant: minibatch_improvement" in config
             assert "criterion: strict" in config
             assert "runner: harbor" in config
@@ -82,6 +106,7 @@ def test_real_recipes_use_harbor_and_method_meta_agent() -> None:
             assert "rollout: {variant: evaluation_replay" in config
             assert "trace_analyzer: {variant: ahe" in config
             assert "meta_agent: {variant: ahe, runner: harbor" in config
+            assert "expose_gate_data: true" in config
             assert "select: {variant: ahe_latest" in config
             assert "gate: {variant: ahe_artifact_valid" in config
             assert "max_tasks: 90" in config
@@ -109,6 +134,7 @@ def test_real_recipes_use_harbor_and_method_meta_agent() -> None:
             assert "rollout: {variant: evaluation_replay" in config
             assert "trace_analyzer: {variant: trace_browser" in config
             assert "meta_agent: {variant: hyperagents" in config
+            assert "expose_gate_data: true" in config
             assert "runner: harbor" in config
             assert "agent: evolve_harbor_agent:FileTaskMiniSweAgent" in config
             assert "editable_roots: [target, operators]" in config
@@ -131,6 +157,7 @@ def test_real_recipes_use_harbor_and_method_meta_agent() -> None:
             assert "rollout: {variant: harbor" in config
             assert "trace_analyzer: {variant: failure_patterns" in config
             assert "meta_agent: {variant: hyperagents, runner: harbor" in config
+            assert "expose_gate_data: false" in config
             assert "agent: codex" in config
             assert "variant: noop" not in config
         assert "mutate:" not in config
@@ -167,6 +194,7 @@ def test_meta_agent_image_provides_harbor_workspace_parent() -> None:
     dockerfile = ROOT / "containers" / "meta-agent" / "Dockerfile"
     contents = dockerfile.read_text()
     assert "WORKDIR /app" in contents
+    assert "git config --system --add safe.directory /app/task/workspace" in contents
     for package in ("git", "jq", "python3", "python-is-python3", "ripgrep", "rsync"):
         assert f"        {package} \\" in contents
     assert "uv tool install --python 3.13 --with fastapi --with orjson mini-swe-agent" in contents

--- a/tests/test_phase_e_recipes.py
+++ b/tests/test_phase_e_recipes.py
@@ -50,7 +50,8 @@ def test_real_recipes_use_harbor_and_method_meta_agent() -> None:
             assert "dataset: swe-bench-lite" in config
             assert "seed: builtin-codex" in config
             assert "rollout: {variant: harbor" in config
-            assert "trace_analyzer: {variant: execution_records" in config
+            assert "trace_analyzer: {variant: trajectory_only" in config
+            assert "trajectory_only: true" in config
             assert "variant: aevolve" in config
             assert "runner: harbor" in config
             assert "agent: codex" in config
@@ -166,7 +167,8 @@ def test_meta_agent_image_provides_harbor_workspace_parent() -> None:
     dockerfile = ROOT / "containers" / "meta-agent" / "Dockerfile"
     contents = dockerfile.read_text()
     assert "WORKDIR /app" in contents
-    assert "python3 python-is-python3" in contents
+    for package in ("git", "jq", "python3", "python-is-python3", "ripgrep", "rsync"):
+        assert f"        {package} \\" in contents
     assert "uv tool install --python 3.13 --with fastapi --with orjson mini-swe-agent" in contents
     assert "COPY uv-wrapper /root/.local/bin/uv" in contents
 

--- a/tests/test_phase_f_init_binding.py
+++ b/tests/test_phase_f_init_binding.py
@@ -14,6 +14,8 @@ def test_real_recipe_binds_harbor_rollout_trace_analyzer_and_hyperagents_meta_ag
     meta_agent = next(binding for binding in bindings if binding.kind == "meta_agent")
 
     assert rollout.source == "library/rollout/harbor.py"
+    assert '"target": "/opt/evolve/uv/cache"' in rollout.text
+    assert '"target": "/installed-agent/uv-cache"' not in rollout.text
     assert trace_analyzer.source == "library/trace_analyzer/failure_patterns.py"
     expected_source = (ROOT / "library" / "meta_agent" / "hyperagents.py").read_text()
     assert meta_agent.source == "library/meta_agent/hyperagents.py"

--- a/tests/test_recipe_inventory.py
+++ b/tests/test_recipe_inventory.py
@@ -10,6 +10,7 @@ def test_repository_contains_only_supported_recipes() -> None:
 
     assert recipe_names == {
         "aevolve",
+        "aevolve_tbench_bridge",
         "ahe",
         "gepa",
         "hill_climb",

--- a/tests/test_trajectory_only_trace_analyzer.py
+++ b/tests/test_trajectory_only_trace_analyzer.py
@@ -1,0 +1,95 @@
+import importlib.util
+import json
+import random
+from pathlib import Path
+from types import SimpleNamespace
+
+from evolve.frozen.interfaces import OperatorContext
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _module():
+    path = ROOT / "library" / "trace_analyzer" / "trajectory_only.py"
+    spec = importlib.util.spec_from_file_location("evolve_test_trajectory_only", path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_trajectory_only_runs_separate_behavior_judge_and_exposes_one_selected_view(
+    tmp_path: Path, monkeypatch
+) -> None:
+    module = _module()
+    checkout = tmp_path / "checkout"
+    run_dir = checkout / "runs" / "gen-1"
+    rollout = run_dir / "rollout"
+    rollout.mkdir(parents=True)
+    (rollout / "cases.json").write_text(
+        json.dumps(
+            [
+                {
+                    "task_name": "terminal/task-a",
+                    "outcome": "failed",
+                    "reward": 0,
+                    "instruction": "ground-truth task text",
+                    "verifier_output": "ground-truth verifier failure",
+                    "trajectory_events": [
+                        {
+                            "type": "tool_call",
+                            "name": "exec",
+                            "arguments": {"cmd": "pytest -q"},
+                        },
+                        {
+                            "type": "tool_result",
+                            "observation": "ERROR: one test failed",
+                        },
+                    ],
+                }
+            ]
+        )
+    )
+    ctx = OperatorContext(
+        workspace=checkout,
+        checkout=checkout,
+        run_dir=run_dir,
+        genid="1",
+        parent=None,
+        round=None,
+        fan_out=1,
+        config={"judge_retry_attempts": 1, "judge_max_concurrent": 1},
+        rng=random.Random(0),
+    )
+    monkeypatch.setattr(module, "_runner_config", lambda _checkout: {"agent": "codex", "model": "gpt-test"})
+    prompts = []
+
+    def fake_judge(_checkout, prompt, _ctx, **_kwargs):
+        prompts.append(prompt)
+        return SimpleNamespace(
+            output=json.dumps(
+                {
+                    "score": 2,
+                    "category": "software-engineering",
+                    "outcome": "The test run failed.",
+                    "failure_reason": "The agent did not repair the failing test.",
+                }
+            ),
+            usage={"usd": 0.01},
+        )
+
+    monkeypatch.setattr(module, "run_readonly_agent", fake_judge)
+
+    result = module.TrajectoryOnly().analyze(checkout, ctx)
+
+    assert len(prompts) == 1
+    assert "pytest -q" in prompts[0]
+    assert "one test failed" in prompts[0]
+    assert "ground-truth task text" not in prompts[0]
+    assert "ground-truth verifier failure" not in prompts[0]
+    selected = (run_dir / "trace_analyzer" / "evidence" / "selected.md").read_text()
+    assert selected.count("### Agent Behavior Analysis (this batch)") == 1
+    assert '"score": 2' in selected
+    assert "ground-truth" not in selected
+    assert result.summary["judge_verdicts"] == 1
+    assert not (run_dir / "trace_analyzer" / "evidence" / "raw_traces.jsonl").exists()


### PR DESCRIPTION
## Summary

- add A-Evolve-compatible `trajectory_only` evidence with complete ordered Harbor events and an independent behavior-only judge
- switch GEPA to file-backed, component-specific reflective evidence and an official agent-proposer-style prompt while retaining full mutable-surface edits
- add an A-Evolve Terminal-Bench bridge recipe with Codex meta-agent execution and MiniSWE source-target evaluation
- make Harbor meta-agent gate visibility configurable through `operators.meta_agent.expose_gate_data`
  - hidden mode keeps filtered `rollout` / `trace_analyzer` / `feedback` evidence from current and prior generations, removes evaluator/archive/gate artifacts, and creates a sanitized Git baseline
  - exposed mode preserves the evaluator, archive, complete run tree, and original Git history for full-benchmark methods
- load evolved MiniSWE skills and JSONL memory into the target runtime, with preflight/runtime evidence that verifies the context was installed
- add Git workspace safety configuration and retain the expanded command environment in the Harbor meta-agent image
- expand recipe, runner, GEPA, MiniSWE wrapper, and evidence-boundary tests

## Why

The previous Harbor bundle behavior coupled evaluator visibility to A-Evolve's `trajectory_only` flag and copied complete run/archive state for other variants. That exposed held-out gate task identities and trajectories to methods that should learn only from train rollouts, while full-benchmark methods still need their certified evaluation history. A method-level visibility flag makes that boundary explicit.

GEPA also embedded a truncated reflective dataset and component snapshot directly into the prompt. File-backed component evidence is closer to the agent-proposer workflow, avoids duplicate prompt payloads, and lets the editing agent inspect the live target before making a coherent surface-valid change.

Finally, MiniSWE source targets previously ignored evolved `skills/` and `memory/` files. The runtime now loads those components so mutations to them can affect downstream benchmark behavior.

## Impact

- `expose_gate_data` defaults to `false`; A-Evolve, GEPA, and hill climb explicitly hide gate data, while AHE and HyperAgents expose full-benchmark history.
- Hidden Harbor workspaces preserve train evidence across generations but omit evaluator, archive, selection, gate, record, and sealed artifacts.
- Existing generated workspaces remain frozen and must be re-initialized to receive the new runner, recipes, and MiniSWE adapter behavior.
- Meta-agent container images must be rebuilt to receive the Dockerfile update.

## Checks

- `.venv/bin/ruff check .`
- `.venv/bin/ty check`
- `.venv/bin/pytest -q` — 394 passed
- `git diff --cached --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a behavior-only `trajectory_only` trace-analyzer mode and bundled outputs (including `trajectory_only.json` in feedback evidence when present).
  * Added workspace contract guidance in meta-agent prompts and a new “truthful workspace contract” prompt section.
  * Introduced a safer workspace run lock to prevent concurrent evolve runs.
  * Expanded evolved-context loading for MiniSWE runtime evidence generation.
* **Bug Fixes**
  * Improved infra-error handling and rejection when no usable cases exist.
  * Enhanced task selection normalization and duplicate/out-of-split validation.
  * Improved evaluator/runner environment temp handling and evidence/trajectory event capture.
* **Documentation**
  * Updated protocol/variant catalogs, recipes, and runner guidance for `trajectory_only` and `expose_gate_data` behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->