### PR TITLE
fix: isolate meta-agent virtual environments

### DIFF
--- a/META_AGENTS.md
+++ b/META_AGENTS.md
@@ -50,13 +50,18 @@ The command must edit files in its current working directory and exit zero.
 Because it is a trusted host command, it can access inherited credentials,
 network, Git metadata, and paths outside the candidate. The mutable-surface
 repair only constrains observable candidate changes; it is not a host sandbox.
+That includes Git-ignored files: a local meta-agent can overwrite the
+workspace's `.venv`, caches, or other untracked state. Use `runner: harbor` when
+the editing agent must not be able to mutate the framework environment.
 
 ## `runner: harbor`: isolated agent with artifact return
 
 The Harbor runner builds a disposable writable experiment workspace at
 `/app/task/workspace`. Gate visibility is controlled by
 `operators.meta_agent.expose_gate_data`, which must be a boolean and defaults to
-`false`.
+`false`. Git-ignored host state, including `.venv` directories, is omitted from
+the disposable copy. A meta-agent may create a new `.venv` inside the task, but
+ignored paths are not imported back into the host checkout.
 
 With `expose_gate_data: false`, the task receives the selected parent,
 configuration, a clean Git baseline, and the `rollout`, `trace_analyzer`, and
@@ -156,6 +161,12 @@ Harbor and the framework are always launched with `uv run --project
 `sys.path` edits are no longer supported. A folder containing only an
 arbitrary executable is not a Harbor agent adapter; use `local` for that
 executable, or package a Harbor adapter class.
+
+`uv --frozen` guarantees that the declared lock is respected; it is not a
+filesystem permission boundary. Isolation comes from the Harbor copy-and-import
+contract above. Candidate dependency preparation also directs `uv sync` to a
+temporary environment under the run directory, rather than `target/.venv`, and
+removes that temporary environment after preparation.
 
 Codex authentication always uses a host `auth.json`: run `codex login` before
 starting the experiment. For `agent: codex`, the Harbor runner automatically

--- a/library/meta_agent/runners/harbor.py
+++ b/library/meta_agent/runners/harbor.py
@@ -38,11 +38,6 @@ _SECRET_ASSIGNMENT = re.compile(
     r"([\"']?)(\s*[:=]\s*)([^\s,;}]+)"
 )
 _BEARER = re.compile(r"(?i)\bbearer\s+[A-Za-z0-9._~+/=-]+")
-_PROXY_ENV = (
-    ("EVOLVE_HARBOR_HTTP_PROXY", "http_proxy", "HTTP_PROXY"),
-    ("EVOLVE_HARBOR_HTTPS_PROXY", "https_proxy", "HTTPS_PROXY"),
-    ("EVOLVE_HARBOR_NO_PROXY", "no_proxy", "NO_PROXY"),
-)
 _CREDENTIAL_ENV = ("OPENAI_API_KEY", "OPENAI_BASE_URL", "OPENAI_API_BASE")
 
 
@@ -527,11 +522,6 @@ def _append_agent_env(command: list[str], config: dict[str, Any]) -> None:
 
 def _agent_env(config: dict[str, Any]) -> dict[str, str]:
     values: dict[str, str] = {}
-    for override, lower, upper in _PROXY_ENV:
-        value = os.environ.get(override) or os.environ.get(lower) or os.environ.get(upper)
-        if value:
-            values[lower] = value
-            values[upper] = value
     for name in _CREDENTIAL_ENV:
         value = os.environ.get(name)
         if value:

--- a/library/meta_agent/runners/harbor.py
+++ b/library/meta_agent/runners/harbor.py
@@ -103,6 +103,42 @@ def _copy_tree(source: Path, destination: Path, *, ignore=None) -> None:
         shutil.copy2(source, destination, follow_symlinks=False)
 
 
+def _ignored_checkout_paths(checkout: Path) -> set[str]:
+    result = git(
+        checkout,
+        "ls-files",
+        "--others",
+        "--ignored",
+        "--exclude-standard",
+        "--directory",
+        "-z",
+    )
+    return {path.rstrip("/") for path in result.stdout.split("\0") if path}
+
+
+def _checkout_copy_ignore(checkout: Path, ignored: set[str]):
+    root = checkout.resolve()
+
+    def ignore(directory: str, names: list[str]) -> set[str]:
+        relative = Path(directory).resolve().relative_to(root)
+        return {
+            name
+            for name in names
+            if (relative / name).as_posix() in ignored
+        }
+
+    return ignore
+
+
+def _copy_checkout_inputs(checkout: Path, workspace: Path, excluded_roots: set[str]) -> None:
+    ignored = _ignored_checkout_paths(checkout)
+    ignore = _checkout_copy_ignore(checkout, ignored)
+    for source in checkout.iterdir():
+        relative = source.relative_to(checkout).as_posix()
+        if source.name not in excluded_roots and relative not in ignored:
+            _copy_tree(source, workspace / source.name, ignore=ignore)
+
+
 def _runs_ignore(runs_root: Path):
     resolved_root = runs_root.resolve()
 
@@ -250,9 +286,11 @@ def _copy_full_workspace_inputs(checkout: Path, ctx: OperatorContext, workspace:
     for path in workspace.iterdir():
         if path.name != ".git":
             _remove(path)
-    for source in checkout.iterdir():
-        if source.name not in {".git", "runs", "archive.jsonl", _EVAL_RECEIPT}:
-            _copy_tree(source, workspace / source.name)
+    _copy_checkout_inputs(
+        checkout,
+        workspace,
+        {".git", "runs", "archive.jsonl", _EVAL_RECEIPT},
+    )
     archive = ctx.workspace / "archive.jsonl"
     if archive.is_file():
         _copy_tree(archive, workspace / "archive.jsonl")
@@ -302,9 +340,7 @@ def _prepare_bundle(
             _copy_full_workspace_inputs(checkout, ctx, workspace)
         else:
             workspace.mkdir()
-            for source in checkout.iterdir():
-                if source.name not in _HIDDEN_WORKSPACE_ROOTS:
-                    _copy_tree(source, workspace / source.name)
+            _copy_checkout_inputs(checkout, workspace, _HIDDEN_WORKSPACE_ROOTS)
             _copy_visible_run_inputs(ctx, workspace)
         _copy_artifact_inputs(ctx, workspace)
         if not _expose_gate_data(ctx.config):

--- a/library/trace_analyzer/ahe.py
+++ b/library/trace_analyzer/ahe.py
@@ -586,6 +586,17 @@ def _change_evaluation(ctx: OperatorContext, cases: list[Case], field_limit: int
 
 def _task_vector_outcome(task: Case) -> str:
     trials = _list(task.get("trials"))
+    rewards = [
+        float(trial["reward"])
+        for trial in trials
+        if isinstance(trial, dict)
+        and isinstance(trial.get("reward"), (int, float))
+        and not isinstance(trial.get("reward"), bool)
+    ]
+    if rewards and len(rewards) == len(trials) and all(reward > 0 for reward in rewards):
+        return "pass"
+    if rewards:
+        return "fail"
     statuses = [str(trial.get("status") or "") for trial in trials if isinstance(trial, dict)]
     if statuses and all(status == "passed" for status in statuses):
         return "pass"

--- a/src/evolve/candidate/smoke.py
+++ b/src/evolve/candidate/smoke.py
@@ -10,8 +10,10 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
+from ..config import load_config
 from ..runtime import owned_attempt_id, run_owned
 from ..surface import surface_patterns
+from ..uv_runtime import prepare_candidate_runtime
 from .snapshot import build_candidate_snapshot, materialize_snapshot
 
 SmokeStatus = Literal["passed", "failed", "unsupported"]
@@ -43,7 +45,29 @@ def run_candidate_smoke(checkout: Path, *, workspace: Path) -> SmokeResult:
         script = materialized / "evaluator" / "smoke.sh"
         if not script.is_file():
             return _write_result(attempt, "unsupported", snapshot.tree, None, "", "", time.monotonic() - started)
+        config = load_config(materialized / "evolve.yaml")
+        evaluator = config.get("evaluator")
+        runtime = prepare_candidate_runtime(
+            materialized,
+            attempt,
+            workspace / "runs" / "runtime",
+            snapshot.tree,
+            evaluator if isinstance(evaluator, dict) else {},
+        )
+        if not runtime.ready:
+            return _write_result(
+                attempt,
+                "failed",
+                snapshot.tree,
+                None,
+                "",
+                _redact(runtime.reason or "candidate runtime preparation failed", os.environ),
+                time.monotonic() - started,
+            )
         env = {**os.environ, "EVOLVE_RUN_DIR": str(attempt), "EVOLVE_ATTEMPT_ID": owned_attempt_id(workspace, attempt)}
+        if runtime.variant is not None:
+            env["EVOLVE_CANDIDATE_RUNTIME_ENV_JSON"] = runtime.environment_json()
+            env["EVOLVE_CANDIDATE_RUNTIME_MOUNTS_JSON"] = runtime.mounts_json()
         env.setdefault("EVOLVE_FRAMEWORK_PYTHON", sys.executable)
         completed = run_owned([str(script)], cwd=materialized, env=env)
     return _write_result(

--- a/src/evolve/driver.py
+++ b/src/evolve/driver.py
@@ -1340,7 +1340,9 @@ def _run_operator_guarded(
 ) -> OperatorResult:
     before = _archive_line_snapshots(workspace, exp_id)
     if checkout.resolve() != workspace.resolve():
-        _write_archive_lines(archive_path(checkout), before[archive_path(workspace)])
+        checkout_archive = archive_path(checkout)
+        before[checkout_archive] = _archive_lines(checkout_archive)
+        _write_archive_lines(checkout_archive, before[archive_path(workspace)])
         receipts = _archive_lines(eval_receipt_path(archive_path(workspace)))
         if receipts:
             _write_archive_lines(eval_receipt_path(archive_path(checkout)), receipts)

--- a/src/evolve/patching.py
+++ b/src/evolve/patching.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import shutil
 from dataclasses import dataclass
 from pathlib import Path
@@ -45,6 +46,8 @@ def create_candidate_patch(
 ) -> CandidatePatch:
     root = Path(checkout).resolve()
     notes: list[str] = []
+    if _restore_unchanged_injected_archive(root, parent_ref):
+        notes.append("ignored unchanged framework-injected archive.jsonl")
     changed = working_tree_changed_paths(root, parent_ref)
     violations = check_paths(changed, surface.include, surface.exclude)
 
@@ -63,6 +66,27 @@ def create_candidate_patch(
         diff = git(root, "diff", "--binary", parent_ref, snapshot.commit, "--").stdout
     surface_report = {"ok": not violations, "mutated": changed, "violations": violations}
     return CandidatePatch(changed_paths=changed, diff=diff, surface_report=surface_report, notes=notes)
+
+
+def _restore_unchanged_injected_archive(root: Path, parent_ref: str) -> bool:
+    workspace_raw = os.environ.get("EVOLVE_WORKSPACE")
+    checkout_raw = os.environ.get("EVOLVE_CHECKOUT")
+    if not workspace_raw or not checkout_raw:
+        return False
+    workspace = Path(workspace_raw).resolve()
+    if workspace == root or Path(checkout_raw).resolve() != root:
+        return False
+    live_archive = workspace / "archive.jsonl"
+    checkout_archive = root / "archive.jsonl"
+    try:
+        unchanged = live_archive.is_file() and checkout_archive.is_file() and (
+            live_archive.read_bytes() == checkout_archive.read_bytes()
+        )
+    except OSError:
+        return False
+    if not unchanged:
+        return False
+    return _repair_surface_path(root, parent_ref, "archive.jsonl") is not None
 
 
 def _candidate_diff(root: Path, parent_ref: str, changed: list[str]) -> str:

--- a/src/evolve/uv_runtime.py
+++ b/src/evolve/uv_runtime.py
@@ -5,6 +5,7 @@ import json
 import re
 import shutil
 import sys
+import tempfile
 import time
 from collections.abc import Mapping
 from dataclasses import dataclass
@@ -17,6 +18,9 @@ from .runtime import run_owned
 
 CONTAINER_UV_CACHE = "/opt/evolve/uv/cache"
 CONTAINER_UV_PYTHON = "/opt/evolve/uv/python"
+CONTAINER_VERIFIER_BIN = "/root/.local/bin"
+CONTAINER_UV_INSTALLER_BIN = "/tmp/evolve-uv-bin"
+CONTAINER_UV_INSTALLER_DOWNLOADS = f"{CONTAINER_VERIFIER_BIN}/uv-installer-downloads"
 RECEIPT_NAME = "candidate-runtime.json"
 FRAMEWORK_PYTHON = f"{sys.version_info.major}.{sys.version_info.minor}"
 
@@ -133,6 +137,23 @@ def _uv_version(uv: str, checkout: Path, env: dict[str, str]) -> str | None:
     return completed.stdout.strip() or None
 
 
+def _normalize_managed_python_links(python_dir: Path) -> None:
+    """Keep uv-managed aliases valid when their directory is bind-mounted."""
+    for link in python_dir.iterdir():
+        if not link.is_symlink():
+            continue
+        target = link.readlink()
+        if not target.is_absolute():
+            continue
+        try:
+            relative = target.relative_to(python_dir)
+        except ValueError:
+            continue
+        temporary = link.with_name(f".{link.name}.relative")
+        temporary.symlink_to(relative)
+        temporary.replace(link)
+
+
 def _write_receipt(
     run_dir: Path,
     config: UvRuntimeConfig,
@@ -207,6 +228,7 @@ def _finish_ready_runtime(
     config: UvRuntimeConfig,
     cache: Path,
     python_dir: Path,
+    verifier_bin: Path,
     *,
     candidate_commit: str,
     dependency_digest: str,
@@ -227,22 +249,72 @@ def _finish_ready_runtime(
         duration_s=time.monotonic() - started,
         reason=None,
     )
+    environment = [
+        ("UV_CACHE_DIR", CONTAINER_UV_CACHE),
+        ("UV_LINK_MODE", "copy"),
+        ("UV_OFFLINE", "1"),
+        ("UV_PYTHON", config.python),
+        ("UV_PYTHON_INSTALL_DIR", CONTAINER_UV_PYTHON),
+    ]
+    if (verifier_bin / "uv-installer-downloads").is_dir():
+        environment.extend(
+            (
+                ("UV_DOWNLOAD_URL", f"file://{CONTAINER_UV_INSTALLER_DOWNLOADS}"),
+                ("UV_UNMANAGED_INSTALL", CONTAINER_UV_INSTALLER_BIN),
+            )
+        )
     return CandidateRuntimeResult(
         config.variant,
         config.project_relative,
-        environment=(
-            ("UV_CACHE_DIR", CONTAINER_UV_CACHE),
-            ("UV_LINK_MODE", "copy"),
-            ("UV_OFFLINE", "1"),
-            ("UV_PYTHON", config.python),
-            ("UV_PYTHON_INSTALL_DIR", CONTAINER_UV_PYTHON),
-        ),
+        environment=tuple(environment),
         mounts=(
             RuntimeMount(cache, CONTAINER_UV_CACHE),
             RuntimeMount(python_dir, CONTAINER_UV_PYTHON),
+            RuntimeMount(verifier_bin, CONTAINER_VERIFIER_BIN, read_only=True),
         ),
         receipt_path=receipt,
     )
+
+
+def _prepare_verifier_bin(
+    uv: str,
+    runtime_root: Path,
+    installer_artifact: str | None = None,
+) -> Path:
+    uv_path = Path(uv).resolve()
+    installer_path = Path(installer_artifact).resolve() if installer_artifact else None
+    digest_input = hashlib.sha256(uv_path.read_bytes())
+    if installer_path is not None:
+        digest_input.update(installer_path.name.encode())
+        digest_input.update(b"\0")
+        digest_input.update(installer_path.read_bytes())
+    digest = digest_input.hexdigest()[:16]
+    destination = runtime_root / f"verifier-bin-{digest}"
+    if destination.is_dir():
+        return destination
+    runtime_root.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(prefix="verifier-bin-", dir=runtime_root) as temporary:
+        staged = Path(temporary)
+        shutil.copy2(uv_path, staged / "uv")
+        (staged / "uvx").write_text('#!/bin/sh\nexec "$HOME/.local/bin/uv" tool run "$@"\n')
+        (staged / "env").write_text(
+            '#!/bin/sh\ncase ":${PATH:-}:" in\n'
+            f'  *":{CONTAINER_UV_INSTALLER_BIN}:"*) ;;\n'
+            f'  *) export PATH="{CONTAINER_UV_INSTALLER_BIN}:$HOME/.local/bin${{PATH:+:$PATH}}" ;;\n'
+            "esac\n"
+        )
+        if installer_path is not None:
+            downloads = staged / "uv-installer-downloads"
+            downloads.mkdir()
+            shutil.copy2(installer_path, downloads / installer_path.name)
+        for path in staged.iterdir():
+            if path.is_file():
+                path.chmod(0o755)
+        try:
+            staged.rename(destination)
+        except FileExistsError:
+            pass
+    return destination
 
 
 def prepare_candidate_runtime(
@@ -314,6 +386,7 @@ def prepare_candidate_runtime(
                 uv_version=None,
                 secret_environment=command_env,
             )
+        _normalize_managed_python_links(python_dir)
         checked = run_owned(
             [uv, "lock", "--check", "--project", str(project)],
             cwd=checkout,
@@ -395,11 +468,17 @@ def prepare_candidate_runtime(
                 secret_environment=command_env,
             )
 
+        verifier_bin = _prepare_verifier_bin(
+            uv,
+            runtime_root,
+            values.get("EVOLVE_UV_INSTALLER_ARTIFACT"),
+        )
         return _finish_ready_runtime(
             run_dir,
             config,
             cache,
             python_dir,
+            verifier_bin,
             candidate_commit=candidate_commit,
             dependency_digest=dependency_digest,
             started=started,

--- a/src/evolve/workspace.py
+++ b/src/evolve/workspace.py
@@ -151,6 +151,7 @@ def _write_files(workspace: Path, config: dict[str, object], *, recipe: str, ini
     partial_floor = float(evaluator.get("partial_floor", 0.8))
     setup_timeout_multiplier = float(evaluator.get("agent_setup_timeout_multiplier", 1))
     agent_timeout_multiplier = float(evaluator.get("agent_timeout_multiplier", 1))
+    verifier_timeout_multiplier = float(evaluator.get("verifier_timeout_multiplier", 1))
     max_retries = int(evaluator.get("max_retries", 0))
     task_scope = str(evaluator.get("task_scope", "partitioned"))
     split = evaluator.get("split")
@@ -205,6 +206,7 @@ def _write_files(workspace: Path, config: dict[str, object], *, recipe: str, ini
             task_file=str(evaluator["task_file"]) if "task_file" in evaluator else None,
             setup_timeout_multiplier=setup_timeout_multiplier,
             agent_timeout_multiplier=agent_timeout_multiplier,
+            verifier_timeout_multiplier=verifier_timeout_multiplier,
             max_retries=max_retries,
         ),
         "evaluator/agent.env": _agent_env(evaluator.get("agent_env")),
@@ -646,6 +648,7 @@ def _eval_env(
     task_file: str | None = None,
     setup_timeout_multiplier: float = 1,
     agent_timeout_multiplier: float = 1,
+    verifier_timeout_multiplier: float = 1,
     max_retries: int = 0,
 ) -> str:
     expected_trials = tasks_per_round * max(trials, 1)
@@ -666,6 +669,8 @@ def _eval_env(
         text += f"EVOLVE_HARBOR_AGENT_SETUP_TIMEOUT_MULTIPLIER={setup_timeout_multiplier}\n"
     if agent_timeout_multiplier > 1:
         text += f"EVOLVE_HARBOR_AGENT_TIMEOUT_MULTIPLIER={agent_timeout_multiplier}\n"
+    if verifier_timeout_multiplier > 1:
+        text += f"EVOLVE_HARBOR_VERIFIER_TIMEOUT_MULTIPLIER={verifier_timeout_multiplier}\n"
     if max_retries > 0:
         text += f"EVOLVE_HARBOR_MAX_RETRIES={max_retries}\n"
     if model:

--- a/templates/evaluator/engines/harbor.sh
+++ b/templates/evaluator/engines/harbor.sh
@@ -170,7 +170,7 @@ if [ -f evaluator/agent.env ]; then
   done < evaluator/agent.env
 fi
 while IFS= read -r runtime_entry || [ -n "$runtime_entry" ]; do
-  [ -n "$runtime_entry" ] && set -- "$@" --ae "$runtime_entry"
+  [ -n "$runtime_entry" ] && set -- "$@" --ae "$runtime_entry" --ve "$runtime_entry"
 done < "$EVOLVE_RUN_DIR/candidate-runtime.env"
 if [ -n "${EVOLVE_CANDIDATE_SMOKE_MODE:-}" ]; then
   set -- "$@" --install-only --ae "EVOLVE_CANDIDATE_SMOKE_MODE=$EVOLVE_CANDIDATE_SMOKE_MODE"
@@ -186,21 +186,15 @@ fi
 if [ -n "${EVOLVE_HARBOR_AGENT_TIMEOUT_MULTIPLIER:-}" ]; then
   set -- "$@" --agent-timeout-multiplier "$EVOLVE_HARBOR_AGENT_TIMEOUT_MULTIPLIER"
 fi
+if [ -n "${EVOLVE_HARBOR_VERIFIER_TIMEOUT_MULTIPLIER:-}" ]; then
+  set -- "$@" --verifier-timeout-multiplier "$EVOLVE_HARBOR_VERIFIER_TIMEOUT_MULTIPLIER"
+fi
 if [ -n "${EVOLVE_HARBOR_MAX_RETRIES:-}" ]; then
   set -- "$@" --max-retries "$EVOLVE_HARBOR_MAX_RETRIES"
   set -- "$@" --retry-exclude AgentTimeoutError
   set -- "$@" --retry-exclude EvolveCandidateInvalidError
   set -- "$@" --retry-exclude ApiUsageLimitError
 fi
-proxy_http=${EVOLVE_HARBOR_HTTP_PROXY:-${http_proxy:-${HTTP_PROXY:-}}}
-proxy_https=${EVOLVE_HARBOR_HTTPS_PROXY:-${https_proxy:-${HTTPS_PROXY:-}}}
-proxy_no=${EVOLVE_HARBOR_NO_PROXY:-${no_proxy:-${NO_PROXY:-}}}
-for proxy_entry in \
-  "http_proxy=$proxy_http" "HTTP_PROXY=$proxy_http" \
-  "https_proxy=$proxy_https" "HTTPS_PROXY=$proxy_https" \
-  "no_proxy=$proxy_no" "NO_PROXY=$proxy_no"; do
-  if [ -n "${proxy_entry#*=}" ]; then set -- "$@" --ae "$proxy_entry" --ve "$proxy_entry"; fi
-done
 set -- "$@" --job-name "$EVOLVE_ATTEMPT_ID" --jobs-dir "$jobs_dir" --n-attempts "${EVOLVE_HARBOR_ATTEMPTS:-1}" -n "${EVOLVE_HARBOR_N_CONCURRENT:-$EVOLVE_HARBOR_N}" -y -q
 if [ -n "${EVOLVE_CANDIDATE_SMOKE_MODE:-}" ]; then
   "$UV" run --project "$EVOLVE_WORKSPACE" --frozen harbor "$@"

--- a/templates/target/harbor/miniswe_source_agent.py
+++ b/templates/target/harbor/miniswe_source_agent.py
@@ -243,9 +243,11 @@ class MiniSweSourceAgent(MiniSweAgent):
                 "set -euo pipefail; "
                 f"unset {' '.join(PROXY_NAMES)}; "
                 'mkdir -p "$HOME/.local/bin"; export PATH="$HOME/.local/bin:$PATH"; '
+                "if ! command -v uv >/dev/null 2>&1 || ! uv --version >/dev/null 2>&1; then "
                 f"if [ -f {HOST_UV_PATH} ]; then "
                 f'cp {HOST_UV_PATH} "$HOME/.local/bin/uv"; chmod 755 "$HOME/.local/bin/uv"; '
                 'if ! "$HOME/.local/bin/uv" --version >/dev/null 2>&1; then rm -f "$HOME/.local/bin/uv"; fi; '
+                "fi; "
                 "fi; "
                 "if ! command -v uv >/dev/null 2>&1 || ! uv --version >/dev/null 2>&1; then "
                 'rm -f "$HOME/.local/bin/uv"; '

--- a/templates/workspace/evolve_harbor_adapter/__init__.py
+++ b/templates/workspace/evolve_harbor_adapter/__init__.py
@@ -246,9 +246,11 @@ class MiniSweSourceAgent(MiniSweAgent):
                 "set -euo pipefail; "
                 f"unset {' '.join(PROXY_NAMES)}; "
                 'mkdir -p "$HOME/.local/bin"; export PATH="$HOME/.local/bin:$PATH"; '
+                "if ! command -v uv >/dev/null 2>&1 || ! uv --version >/dev/null 2>&1; then "
                 f"if [ -f {HOST_UV_PATH} ]; then "
                 f'cp {HOST_UV_PATH} "$HOME/.local/bin/uv"; chmod 755 "$HOME/.local/bin/uv"; '
                 'if ! "$HOME/.local/bin/uv" --version >/dev/null 2>&1; then rm -f "$HOME/.local/bin/uv"; fi; '
+                "fi; "
                 "fi; "
                 "if ! command -v uv >/dev/null 2>&1 || ! uv --version >/dev/null 2>&1; then "
                 'rm -f "$HOME/.local/bin/uv"; '

--- a/tests/test_ahe_trace_analyzer.py
+++ b/tests/test_ahe_trace_analyzer.py
@@ -343,6 +343,51 @@ def test_ahe_archive_analysis_marks_two_observation_flip_as_possibly_unstable(tm
     assert analysis["stability"]["unstable"] == []
 
 
+def test_ahe_archive_analysis_classifies_canonical_benchmark_complete_rewards(tmp_path: Path) -> None:
+    module = _module()
+    ctx = _ctx(tmp_path, genid="2", parent="1")
+    rows = []
+    for genid, passing_reward in (("0", 1.0), ("1", 0.0)):
+        rows.append(
+            {
+                "genid": genid,
+                "score": passing_reward,
+                "selection_eligible": True,
+                "task_vector": {
+                    "schema_version": 1,
+                    "tasks": {
+                        "flip": {
+                            "trials": [
+                                {
+                                    "status": "benchmark_complete",
+                                    "reward": passing_reward,
+                                    "owner": "benchmark",
+                                }
+                            ]
+                        },
+                        "always-fail": {
+                            "trials": [
+                                {"status": "benchmark_complete", "reward": 0.0, "owner": "benchmark"}
+                            ]
+                        },
+                        "infra": {
+                            "trials": [
+                                {"status": "infrastructure_failed", "reward": None, "owner": "infrastructure"}
+                            ]
+                        },
+                    },
+                },
+            }
+        )
+    _write_archive(ctx, rows)
+
+    analysis = module._archive_analysis(ctx)
+
+    assert analysis["stability"]["possibly_unstable"] == ["flip"]
+    assert analysis["stability"]["stable_fail"] == ["always-fail"]
+    assert analysis["stability"]["infra_only"] == ["infra"]
+
+
 def test_ahe_analyzer_renders_archive_analysis_in_overview(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     module = _module()
     ctx = _ctx(tmp_path, genid="2", parent="1")

--- a/tests/test_candidate_smoke.py
+++ b/tests/test_candidate_smoke.py
@@ -11,6 +11,7 @@ from conftest import git, run_evolve
 from evolve.candidate import smoke as candidate_smoke_module
 from evolve.candidate.smoke import run_candidate_smoke
 from evolve.config import default_config
+from evolve.uv_runtime import CandidateRuntimeResult, RuntimeMount
 from evolve.workspace import InitOptions, init_workspace
 
 ANSI_ESCAPE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
@@ -89,6 +90,48 @@ def test_smoke_runs_through_owned_process_helper(tmp_path: Path, monkeypatch) ->
         checkout,
         result.attempt_dir,
     )
+
+
+def test_smoke_prepares_and_injects_candidate_runtime(tmp_path: Path, monkeypatch) -> None:
+    checkout = smoke_checkout(tmp_path)
+    (checkout / "evolve.yaml").write_text(
+        "surface:\n"
+        "  include: [target/**]\n"
+        "  exclude: []\n"
+        "evaluator:\n"
+        "  candidate_runtime: {variant: uv, project: target, python: '3.12'}\n"
+    )
+    git(checkout, "add", "evolve.yaml")
+    git(checkout, "commit", "--amend", "--no-edit", "-q")
+    runtime_calls = []
+    run_env = {}
+
+    def fake_prepare(materialized, attempt, runtime_root, candidate_commit, evaluator):
+        runtime_calls.append((materialized, attempt, runtime_root, candidate_commit, evaluator))
+        return CandidateRuntimeResult(
+            "uv",
+            "target",
+            environment=(("UV_OFFLINE", "1"),),
+            mounts=(RuntimeMount(tmp_path / "cache", "/opt/evolve/uv/cache"),),
+        )
+
+    def fake_run_owned(command, *, cwd, env, timeout_s=None):
+        del command, cwd, timeout_s
+        run_env.update(env)
+        return SimpleNamespace(returncode=0, stdout="", stderr="", wall_s=0.01, timed_out=False)
+
+    monkeypatch.setattr(candidate_smoke_module, "prepare_candidate_runtime", fake_prepare, raising=False)
+    monkeypatch.setattr(candidate_smoke_module, "run_owned", fake_run_owned)
+
+    result = run_candidate_smoke(checkout, workspace=checkout)
+
+    assert result.status == "passed"
+    assert len(runtime_calls) == 1
+    assert runtime_calls[0][1] == result.attempt_dir
+    assert runtime_calls[0][2] == checkout / "runs" / "runtime"
+    assert runtime_calls[0][4]["candidate_runtime"]["variant"] == "uv"
+    assert json.loads(run_env["EVOLVE_CANDIDATE_RUNTIME_ENV_JSON"]) == {"UV_OFFLINE": "1"}
+    assert json.loads(run_env["EVOLVE_CANDIDATE_RUNTIME_MOUNTS_JSON"])[0]["target"] == "/opt/evolve/uv/cache"
 
 
 def test_smoke_redacts_proxy_credential_only(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_harbor_evaluator_config.py
+++ b/tests/test_harbor_evaluator_config.py
@@ -53,6 +53,21 @@ def test_eval_env_freezes_agent_timeout_multiplier() -> None:
     assert "EVOLVE_HARBOR_AGENT_TIMEOUT_MULTIPLIER=4\n" in env
 
 
+def test_eval_env_freezes_verifier_timeout_multiplier() -> None:
+    env = _eval_env(
+        "exp",
+        "terminal-bench-2",
+        n_concurrent=8,
+        tasks_per_round=30,
+        trials=1,
+        partial_floor=0.8,
+        agent="evolve_harbor_adapter:MiniSweSourceAgent",
+        verifier_timeout_multiplier=2,
+    )
+
+    assert "EVOLVE_HARBOR_VERIFIER_TIMEOUT_MULTIPLIER=2\n" in env
+
+
 def test_eval_env_and_environment_kwargs_render_local_backend() -> None:
     env = _eval_env(
         "exp",

--- a/tests/test_harbor_evaluator_template.py
+++ b/tests/test_harbor_evaluator_template.py
@@ -47,6 +47,12 @@ def test_harbor_evaluator_passes_agent_timeout_multiplier() -> None:
     assert '--agent-timeout-multiplier "$EVOLVE_HARBOR_AGENT_TIMEOUT_MULTIPLIER"' in text
 
 
+def test_harbor_evaluator_passes_verifier_timeout_multiplier() -> None:
+    text = _eval_sh("harbor", "fixture")
+
+    assert '--verifier-timeout-multiplier "$EVOLVE_HARBOR_VERIFIER_TIMEOUT_MULTIPLIER"' in text
+
+
 def test_harbor_evaluator_forwards_workspace_openai_environment() -> None:
     text = _eval_sh("harbor", "fixture")
 
@@ -107,6 +113,9 @@ def test_harbor_evaluator_forwards_custom_environment_and_skips_docker_cleanup(t
         "EVOLVE_RUN_DIR": str(tmp_path / "run"),
         "EVOLVE_ATTEMPT_ID": "local-attempt",
         "EVOLVE_FRAMEWORK_PYTHON": sys.executable,
+        "http_proxy": "http://dependency-proxy.example:8118",
+        "https_proxy": "http://dependency-proxy.example:8118",
+        "no_proxy": ".internal.example",
     }
 
     result = subprocess.run([str(evaluator / "eval.sh")], cwd=tmp_path, env=env, text=True, capture_output=True)
@@ -115,6 +124,8 @@ def test_harbor_evaluator_forwards_custom_environment_and_skips_docker_cleanup(t
     args = args_capture.read_text().splitlines()
     assert args[args.index("--env") + 1] == "evolve.harbor_local:LocalEnvironment"
     assert args[args.index("--environment-kwarg") + 1] == 'workdir="/workspace"'
+    assert not any("dependency-proxy.example" in arg for arg in args)
+    assert not any(".internal.example" in arg for arg in args)
     assert not docker_marker.exists()
 
 
@@ -266,8 +277,10 @@ def test_harbor_smoke_is_install_only_and_exposes_raw_diagnostics(tmp_path: Path
     mounts = json.loads(args[args.index("--mounts") + 1])
     assert mounts == runtime_mounts
     agent_environment = [args[index + 1] for index, value in enumerate(args) if value == "--ae"]
+    verifier_environment = [args[index + 1] for index, value in enumerate(args) if value == "--ve"]
     for key, value in runtime_env.items():
         assert f"{key}={value}" in agent_environment
+        assert f"{key}={value}" in verifier_environment
     assert not (run_dir / "harbor-result.json").exists()
     assert not (run_dir / "score").exists()
 

--- a/tests/test_harbor_meta_agent.py
+++ b/tests/test_harbor_meta_agent.py
@@ -51,6 +51,18 @@ def test_harbor_meta_agent_forwards_openai_environment(monkeypatch: pytest.Monke
     )["OPENAI_BASE_URL"] == "https://configured.example/v1"
 
 
+def test_harbor_meta_agent_does_not_forward_dependency_proxies(monkeypatch: pytest.MonkeyPatch) -> None:
+    module = _harbor_runner_module()
+    monkeypatch.setenv("OPENAI_API_KEY", "workspace-key")
+    monkeypatch.setenv("http_proxy", "http://dependency-proxy.example:8118")
+    monkeypatch.setenv("HTTPS_PROXY", "http://dependency-proxy.example:8118")
+    monkeypatch.setenv("EVOLVE_HARBOR_NO_PROXY", ".internal.example")
+
+    assert module._agent_env({"agent": "mini-swe-agent"}) == {
+        "OPENAI_API_KEY": "workspace-key",
+    }
+
+
 def test_harbor_rejects_oversized_instruction_with_unsafe_agent(tmp_path: Path) -> None:
     runner = _harbor_runner_module()
     prompt = tmp_path / "prompt.md"

--- a/tests/test_harbor_meta_agent.py
+++ b/tests/test_harbor_meta_agent.py
@@ -783,6 +783,33 @@ def test_harbor_bundle_never_exposes_gate_or_sealed_data(tmp_path: Path, traject
         shutil.rmtree(bundle.staging, ignore_errors=True)
 
 
+@pytest.mark.parametrize("expose_gate_data", [False, True])
+def test_harbor_bundle_omits_gitignored_virtual_environments(
+    tmp_path: Path,
+    expose_gate_data: bool,
+) -> None:
+    checkout, run_dir = _checkout(tmp_path)
+    (checkout / ".gitignore").write_text("artifacts/\n.venv/\n")
+    (checkout / ".venv").mkdir()
+    (checkout / ".venv" / "framework-state.txt").write_text("host framework environment\n")
+    (checkout / "target" / ".venv").mkdir()
+    (checkout / "target" / ".venv" / "candidate-state.txt").write_text("host candidate environment\n")
+    runner = _harbor_runner_module()
+    surface = runner.load_surface_policy(checkout)
+    ctx = _ctx(checkout, run_dir)
+    ctx.config["expose_gate_data"] = expose_gate_data
+
+    bundle = runner._prepare_bundle(checkout, ctx, ["target"], surface)
+
+    try:
+        assert not (bundle.workspace / ".venv").exists()
+        assert not (bundle.workspace / "target" / ".venv").exists()
+        assert (checkout / ".venv" / "framework-state.txt").read_text() == "host framework environment\n"
+        assert (checkout / "target" / ".venv" / "candidate-state.txt").read_text() == "host candidate environment\n"
+    finally:
+        shutil.rmtree(bundle.staging, ignore_errors=True)
+
+
 @pytest.mark.parametrize("leak_source", ["prompt", "train-evidence"])
 def test_harbor_bundle_rejects_private_task_identifiers(tmp_path: Path, leak_source: str) -> None:
     checkout, run_dir = _checkout(tmp_path)

--- a/tests/test_locked_runtime.py
+++ b/tests/test_locked_runtime.py
@@ -100,7 +100,16 @@ def test_uv_runtime_prepares_cache_and_emits_offline_contract(tmp_path: Path) ->
     assert [mount.target for mount in result.mounts] == [
         "/opt/evolve/uv/cache",
         "/opt/evolve/uv/python",
+        "/root/.local/bin",
     ]
+    verifier_tools = result.mounts[-1]
+    assert verifier_tools.read_only is True
+    assert (verifier_tools.source / "uv").is_file()
+    assert (verifier_tools.source / "uvx").read_text().startswith("#!/bin/sh\n")
+    assert (verifier_tools.source / "env").read_text().startswith("#!/bin/sh\n")
+    assert (verifier_tools.source / "uv").stat().st_mode & 0o111
+    assert (verifier_tools.source / "uvx").stat().st_mode & 0o111
+    assert (verifier_tools.source / "env").stat().st_mode & 0o111
     receipt = json.loads((run_dir / "candidate-runtime.json").read_text())
     assert receipt["variant"] == "uv"
     assert receipt["project"] == "target"
@@ -110,12 +119,52 @@ def test_uv_runtime_prepares_cache_and_emits_offline_contract(tmp_path: Path) ->
     assert not (run_dir / ".candidate-runtime-venv").exists()
 
 
+def test_uv_runtime_can_stage_an_immutable_uv_installer_artifact(tmp_path: Path) -> None:
+    artifact = tmp_path / "uv-x86_64-unknown-linux-gnu.tar.gz"
+    artifact.write_bytes(b"exact pinned uv archive")
+
+    result, _, _ = _prepare(
+        tmp_path,
+        UV_OFFLINE_RC="0",
+        EVOLVE_UV_INSTALLER_ARTIFACT=str(artifact),
+    )
+
+    assert result.ready
+    environment = dict(result.environment)
+    assert environment["UV_DOWNLOAD_URL"] == "file:///root/.local/bin/uv-installer-downloads"
+    assert environment["UV_UNMANAGED_INSTALL"] == "/tmp/evolve-uv-bin"
+    verifier_tools = result.mounts[-1].source
+    assert (verifier_tools / "uv-installer-downloads" / artifact.name).read_bytes() == artifact.read_bytes()
+    assert "/tmp/evolve-uv-bin:$HOME/.local/bin" in (verifier_tools / "env").read_text()
+
+
 def test_uv_runtime_prepares_the_framework_python_for_offline_consumers(tmp_path: Path) -> None:
     result, _, calls = _prepare(tmp_path, UV_OFFLINE_RC="0")
 
     assert result.ready
     invocations = [json.loads(line) for line in calls.read_text().splitlines()]
     assert ["python", "install", "3.12"] in invocations
+
+
+def test_uv_runtime_makes_managed_python_aliases_portable_for_mounts(tmp_path: Path) -> None:
+    checkout, run_dir, runtime_root, evaluator, env, _ = _runtime_fixture(tmp_path)
+    python_dir = runtime_root / "uv-python"
+    versioned = python_dir / "cpython-3.12.13-linux-x86_64-gnu"
+    versioned.mkdir(parents=True)
+    alias = python_dir / "cpython-3.12-linux-x86_64-gnu"
+    alias.symlink_to(versioned)
+
+    result = prepare_candidate_runtime(
+        checkout,
+        run_dir,
+        runtime_root,
+        candidate_commit="abc123",
+        evaluator=evaluator,
+        env=env,
+    )
+
+    assert result.ready
+    assert alias.readlink() == Path(versioned.name)
 
 
 def test_uv_runtime_warms_local_build_requirements_before_consumers(tmp_path: Path) -> None:

--- a/tests/test_m5_operator_runner.py
+++ b/tests/test_m5_operator_runner.py
@@ -1,6 +1,7 @@
 import textwrap
 from pathlib import Path
 
+from evolve.driver import _run_operator_guarded
 from evolve.operators import OperatorResult, run_operator
 
 
@@ -85,3 +86,31 @@ def test_run_operator_nonzero_and_timeout(tmp_path):
     )
     assert timed_out.returncode == -1
     assert "timeout" in timed_out.stderr.lower()
+
+
+def test_guarded_operator_restores_archive_in_child_checkout(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    checkout = tmp_path / "checkout"
+    run_dir = workspace / "runs" / "gen-1"
+    workspace.mkdir()
+    checkout.mkdir()
+    live_archive = '{"genid":"0","score":0.5}\n'
+    (workspace / "archive.jsonl").write_text(live_archive)
+    (checkout / "archive.jsonl").write_text("")
+    _write_operator(checkout, "probe", "pass\n")
+
+    result = _run_operator_guarded(
+        name="probe",
+        checkout=checkout,
+        workspace=workspace,
+        exp_id="experiment",
+        genid="1",
+        parent="0",
+        run_dir=run_dir,
+        config_block={},
+        timeout_s=30,
+    )
+
+    assert result.returncode == 0
+    assert (workspace / "archive.jsonl").read_text() == live_archive
+    assert (checkout / "archive.jsonl").read_text() == ""

--- a/tests/test_miniswe_harbor_wrapper.py
+++ b/tests/test_miniswe_harbor_wrapper.py
@@ -318,9 +318,11 @@ def test_miniswe_wrapper_subclasses_harbor_miniswe_and_installs_candidate_source
     assert issubclass(module.MiniSweSourceAgent, base)
     assert environment.uploads == [(target.resolve(), "/installed-agent/miniswe-source"), (host_uv, "/tmp/evolve-uv")]
     joined = "\n".join(environment.commands)
+    bootstrap = environment.commands[0]
     assert "apt-get" not in joined
     assert "apk add" not in joined
     assert 'cp /tmp/evolve-uv "$HOME/.local/bin/uv"' in joined
+    assert bootstrap.index("if ! command -v uv") < bootstrap.index('cp /tmp/evolve-uv "$HOME/.local/bin/uv"')
     assert '"$HOME/.local/bin/uv" --version' in joined
     assert 'rm -f "$HOME/.local/bin/uv"' in joined
     assert "uv tool install" not in joined

--- a/tests/test_patching.py
+++ b/tests/test_patching.py
@@ -104,6 +104,59 @@ def test_create_candidate_patch_reports_remaining_violation_when_repair_disabled
     assert patch.notes == []
 
 
+def test_create_candidate_patch_ignores_unchanged_injected_live_archive(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    root = _repo(tmp_path)
+    live_archive = '{"genid":"0","score":0.5}\n'
+    (workspace / "archive.jsonl").write_text(live_archive)
+    (root / "archive.jsonl").write_text(live_archive)
+    (root / "target" / "agent.py").write_text("print('child')\n")
+    monkeypatch.setenv("EVOLVE_WORKSPACE", str(workspace))
+    monkeypatch.setenv("EVOLVE_CHECKOUT", str(root))
+
+    patch = create_candidate_patch(
+        checkout=root,
+        parent_ref="gen/0",
+        surface=SurfacePolicy(include=["target/**"], exclude=[]),
+        repair=False,
+    )
+
+    assert patch.changed_paths == ["target/agent.py"]
+    assert patch.surface_report == {"ok": True, "mutated": ["target/agent.py"], "violations": []}
+    assert "archive.jsonl" not in patch.diff
+    assert not (root / "archive.jsonl").exists()
+
+
+def test_create_candidate_patch_keeps_agent_modified_injected_archive_as_violation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    root = _repo(tmp_path)
+    (workspace / "archive.jsonl").write_text('{"genid":"0","score":0.5}\n')
+    (root / "archive.jsonl").write_text('{"genid":"0","score":0.9}\n')
+    monkeypatch.setenv("EVOLVE_WORKSPACE", str(workspace))
+    monkeypatch.setenv("EVOLVE_CHECKOUT", str(root))
+
+    patch = create_candidate_patch(
+        checkout=root,
+        parent_ref="gen/0",
+        surface=SurfacePolicy(include=["target/**"], exclude=[]),
+        repair=False,
+    )
+
+    assert patch.changed_paths == ["archive.jsonl"]
+    assert patch.surface_report == {
+        "ok": False,
+        "mutated": ["archive.jsonl"],
+        "violations": ["archive.jsonl"],
+    }
+    assert (root / "archive.jsonl").exists()
+
+
 def test_create_candidate_patch_rejects_already_staged_path(tmp_path: Path) -> None:
     root = _repo(tmp_path)
     (root / "target" / "agent.py").write_text("print('child')\n")


### PR DESCRIPTION
## What changed

- omit Git-ignored host state, including root and nested `.venv` directories, when building Harbor meta-agent workspaces
- preserve the behavior in both `expose_gate_data` modes
- document that `uv --frozen` enforces dependency locking but is not a filesystem sandbox
- document that `runner: local` remains a trusted host command and can mutate ignored state

## Root cause

The Harbor runner transactionally ignored `.venv` on return, and candidate runtime preparation already used a temporary `UV_PROJECT_ENVIRONMENT`, but initial Harbor bundle creation still physically copied ignored host environments into the disposable task. This could let an agent alter the disposable copy and fail the surface gate, even though it could not corrupt the host checkout. Local runners can directly change the checkout by design.

## Validation

- regression test observed failing before the implementation and passing after it
- `uv run pytest -q` — 430 passed
- `uv run ruff check .` — passed
- `uv run ty check` — passed