### PR TITLE
Fix exact private task identifier matching

### DIFF
--- a/library/meta_agent/runners/harbor.py
+++ b/library/meta_agent/runners/harbor.py
@@ -48,6 +48,7 @@ _RETRY_EXCLUDE_EXCEPTIONS = (
 )
 _VISIBLE_RUN_INPUTS = ("rollout", "trace_analyzer", "feedback")
 _HIDDEN_WORKSPACE_ROOTS = {".git", ".venv", "runs", "artifacts", "archive.jsonl", _EVAL_RECEIPT, "evaluator"}
+_TASK_IDENTIFIER_CHARACTERS = rb"A-Za-z0-9_.-"
 _SECRET_ASSIGNMENT = re.compile(
     r"(?i)\b([a-z0-9_-]*(?:api[_-]?key|access[_-]?token|auth(?:orization)?|secret|password))\b"
     r"([\"']?)(\s*[:=]\s*)([^\s,;}]+)"
@@ -295,31 +296,45 @@ def _private_task_names(workspace: Path) -> tuple[str, ...]:
     return tuple(sorted(names))
 
 
-def _contains_private_task_name(path: Path, encoded_names: tuple[bytes, ...]) -> bool:
-    overlap = max((len(name) for name in encoded_names), default=1) - 1
+def _contains_private_task_name(
+    path: Path,
+    pattern: re.Pattern[bytes],
+    overlap: int,
+) -> bool:
     tail = b""
     try:
         with path.open("rb") as stream:
             while chunk := stream.read(1024 * 1024):
                 content = tail + chunk
-                if any(name in content for name in encoded_names):
+                match = pattern.search(content)
+                if match is not None and match.end() < len(content):
                     return True
-                tail = content[-overlap:] if overlap else b""
+                tail = content[-overlap:]
     except OSError:
         return False
-    return False
+    return pattern.search(tail) is not None
 
 
 def _assert_private_tasks_absent(workspace: Path, prompt: str, private_names: tuple[str, ...]) -> None:
     if not private_names:
         return
-    if any(name in prompt for name in private_names):
-        raise RuntimeError("Harbor meta-agent prompt contains a private gate/sealed task identifier")
     encoded_names = tuple(name.encode() for name in private_names)
+    pattern = re.compile(
+        rb"(?<!["
+        + _TASK_IDENTIFIER_CHARACTERS
+        + rb"])(?:"
+        + rb"|".join(re.escape(name) for name in encoded_names)
+        + rb")(?!["
+        + _TASK_IDENTIFIER_CHARACTERS
+        + rb"])"
+    )
+    if pattern.search(prompt.encode()):
+        raise RuntimeError("Harbor meta-agent prompt contains a private gate/sealed task identifier")
+    overlap = max(len(name) for name in encoded_names) + 1
     for path in workspace.rglob("*"):
         if not path.is_file() or ".git" in path.relative_to(workspace).parts:
             continue
-        if _contains_private_task_name(path, encoded_names):
+        if _contains_private_task_name(path, pattern, overlap):
             raise RuntimeError("Harbor meta-agent workspace contains a private gate/sealed task identifier")
 
 

--- a/tests/test_harbor_meta_agent.py
+++ b/tests/test_harbor_meta_agent.py
@@ -1124,6 +1124,36 @@ def test_harbor_bundle_rejects_private_task_identifiers(tmp_path: Path, leak_sou
         )
 
 
+def test_harbor_bundle_allows_private_name_prefix_in_training_identifier(tmp_path: Path) -> None:
+    checkout, run_dir = _checkout(tmp_path)
+    evaluator = checkout / "evaluator"
+    evaluator.mkdir()
+    (evaluator / "splits.json").write_text(
+        json.dumps(
+            {
+                "tasks": {
+                    "train": ["tau3-airline-11"],
+                    "gate": ["tau3-airline-1"],
+                    "sealed": [],
+                }
+            }
+        )
+    )
+    evidence = run_dir / "trace_analyzer" / "evidence" / "raw_traces.jsonl"
+    evidence.write_text('{"task_name":"tau3-airline-11"}\n')
+    runner = _harbor_runner_module()
+    surface = runner.load_surface_policy(checkout)
+
+    bundle = runner._prepare_bundle(
+        checkout,
+        _ctx(checkout, run_dir),
+        ["target"],
+        surface,
+        prompt="analyze tau3-airline-11",
+    )
+    shutil.rmtree(bundle.staging, ignore_errors=True)
+
+
 def test_harbor_bundle_exposes_gate_data_only_when_enabled(tmp_path: Path) -> None:
     checkout, run_dir = _checkout(tmp_path)
     evaluator = checkout / "evaluator"


### PR DESCRIPTION
## What changed
- Match private gate/sealed task identifiers on identifier boundaries instead of raw byte substrings.
- Preserve streaming file scans across chunk boundaries.
- Add a regression test for the tau3 collision `tau3-airline-1` vs `tau3-airline-11`.

## Why
The raw substring check rejected legitimate training evidence whenever a private numeric task ID was a prefix of a longer training ID. This caused every HyperAgents×tau3 meta-agent generation to fail before launch.

## Validation
- `ruff check` and `ruff format --check`
- `pytest -q tests/test_harbor_meta_agent.py tests/test_recipe_composition.py` — 68 passed
- Full suite: 509 passed; the five initial failures were sandbox-only UV-cache permission failures and passed when rerun with normal cache access.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task identifier detection to recognize private task names only when they appear as complete identifiers.
  * Prevented valid training identifiers with private-looking prefixes from being incorrectly rejected.
  * Added safeguards for detecting private task identifiers in prompts and workspace content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->