### PR TITLE
Remove unused candidate tools abstraction

### DIFF
--- a/library/meta_agent/aevolve.py
+++ b/library/meta_agent/aevolve.py
@@ -208,8 +208,6 @@ def _instructions(config: dict[str, Any], template_rule: str, *, trajectory_only
         instructions.append("Update the runtime prompt only with concise, transferable instructions.")
     if _enabled(config, "evolve_memory", True):
         instructions.append("Add or prune long-term memory only when the lesson should apply across tasks.")
-    if _enabled(config, "evolve_tools", False):
-        instructions.append("Add or modify candidate-owned tools only when their runtime invocation is verified.")
     instructions.extend(
         [
             "Do not add standalone files to a disabled context layer unless the same change wires them into runtime.",
@@ -297,7 +295,6 @@ def build_prompt(
         raise ValueError(f"A-Evolve prompt_path must reference an existing file: {prompt_relative}")
     skills_dir, skills_relative = _relative_path(checkout, ctx.config.get("skills_dir"), "target/skills")
     _, memory_relative = _relative_path(checkout, ctx.config.get("memory_dir"), "target/memory")
-    _, tools_relative = _relative_path(checkout, ctx.config.get("tools_dir"), "target/tools")
     trajectory_only = _selected_variant(ctx) == TRAJECTORY_ONLY_VARIANT
     summaries = [] if trajectory_only else _case_summaries(ctx)
     tasks_analyzed = _selected_case_count(ctx) if trajectory_only else len(summaries)
@@ -313,14 +310,12 @@ def build_prompt(
         f"- Runtime prompt/config: `{prompt_relative}`\n"
         f"- Reusable skills: `{skills_relative}/*/SKILL.md`\n"
         f"- Draft skills: `{skills_relative}/_drafts/*.md`\n"
-        f"- Memory: `{memory_relative}/`\n"
-        f"- Tools: `{tools_relative}/`\n\n"
+        f"- Memory: `{memory_relative}/`\n\n"
         f"{workspace_contract(checkout, ctx.config)}\n\n"
         "### Managed Evolution Layers\n"
         f"- Prompt evolution: {_layer_status(ctx.config, 'evolve_prompts', True)}\n"
         f"- Skills evolution: {_layer_status(ctx.config, 'evolve_skills', True)}\n"
         f"- Memory evolution: {_layer_status(ctx.config, 'evolve_memory', True)}\n"
-        f"- Tools evolution: {_layer_status(ctx.config, 'evolve_tools', False)}\n"
         "These switches control which reusable context stores A-Evolve should manage; they are not filesystem permissions.\n\n"
         + (
             f"{_evidence_section(observation, ctx, trajectory_only=True)}\n\n"

--- a/library/meta_agent/support/workspace.py
+++ b/library/meta_agent/support/workspace.py
@@ -78,7 +78,6 @@ def workspace_contract(
     prompt = _detected_prompt(checkout, config)
     skills = _detected_directory(checkout, config, "skills_dir", "target/skills")
     memory = _detected_directory(checkout, config, "memory_dir", "target/memory")
-    tools = _detected_directory(checkout, config, "tools_dir", "target/tools")
     permissions = "\n".join(f"- You CAN modify any file under `{root}/`." for root in roots)
     scope = (
         "- This method further restricts the current proposal to: "
@@ -94,13 +93,12 @@ def workspace_contract(
         f"- Enforced surface include: {includes}\n"
         f"- Enforced surface exclude: {excludes}\n"
         f"{scope}\n\n"
-        "`prompt_path`, `skills_dir`, `memory_dir`, and `tools_dir` identify runtime components; "
+        "`prompt_path`, `skills_dir`, and `memory_dir` identify runtime components; "
         "they do not narrow the mutation permission above.\n\n"
         "## Runtime Context Locations\n\n"
         f"{_location('Runtime prompt/config', prompt)}\n"
         f"{_location('Reusable skills', skills)}\n"
-        f"{_location('Long-term memory', memory)}\n"
-        f"{_location('Candidate-owned tools', tools)}\n\n"
-        "A file in a skills, memory, or tools directory affects the deployed agent only if the candidate runtime "
+        f"{_location('Long-term memory', memory)}\n\n"
+        "A file in a skills or memory directory affects the deployed agent only if the candidate runtime "
         "loads or invokes it. When proposing such a file, verify or implement that runtime path in the same candidate."
     )

--- a/recipes/aevolve/evolve.yaml
+++ b/recipes/aevolve/evolve.yaml
@@ -29,11 +29,9 @@ operators:
     evolve_prompts: true
     evolve_skills: true
     evolve_memory: false
-    evolve_tools: false
     prompt_path: target/prompt.md
     skills_dir: target/skills
     memory_dir: target/memory
-    tools_dir: target/tools
     history_cycles: 2
     max_observations: 30
     feedback_chars: 300

--- a/recipes/ahe/evolve.yaml
+++ b/recipes/ahe/evolve.yaml
@@ -17,7 +17,7 @@ operators:
   select: {variant: ahe_latest, timeout_s: 600}
   rollout: {variant: parent_evaluation, field_limit: 2000, timeout_s: 600}
   trace_analyzer: {variant: ahe, max_tasks: 30, max_concurrent: 10, timeout_per_task: 600, retry_attempts: 1, debugger_agent_kwargs: {reasoning_effort: high, max_tokens: 64000}, field_limit: 2000, timeout_s: 3600}
-  meta_agent: {variant: ahe, runner: harbor, expose_gate_data: false, agent: evolve.integrations.harbor.miniswe_task_file:InstalledMiniSweAgent, model: openai/gpt-5.4-2026-03-05, environment: docker, image: evolve-meta-agent-app:20260724-tools-mswe245, editable_roots: [target], prompt_path: target/src/minisweagent/config/mini.yaml, skills_dir: target/skills, memory_dir: target/memory, tools_dir: target/tools, agent_kwargs: {reasoning_effort: high, cost_limit: 0, max_tokens: 64000}, max_retries: 1, timeout_s: 3600}
+  meta_agent: {variant: ahe, runner: harbor, expose_gate_data: false, agent: evolve.integrations.harbor.miniswe_task_file:InstalledMiniSweAgent, model: openai/gpt-5.4-2026-03-05, environment: docker, image: evolve-meta-agent-app:20260724-tools-mswe245, editable_roots: [target], prompt_path: target/src/minisweagent/config/mini.yaml, skills_dir: target/skills, memory_dir: target/memory, agent_kwargs: {reasoning_effort: high, cost_limit: 0, max_tokens: 64000}, max_retries: 1, timeout_s: 3600}
   gate: {variant: ahe_artifact_valid, timeout_s: 600}
   record: {variant: jsonl, timeout_s: 600}
   timeout_s: 600

--- a/recipes/hill_climb/evolve.yaml
+++ b/recipes/hill_climb/evolve.yaml
@@ -18,7 +18,7 @@ operators:
   select: {variant: greedy}
   rollout: {variant: harbor, budget_tasks: 32, n_concurrent: 16, agent_setup_timeout_multiplier: 1, max_retries: 1, timeout_s: 3600}
   trace_analyzer: {variant: failure_patterns, max_chars: 30000, timeout_s: 600}
-  meta_agent: {variant: hyperagents, runner: harbor, expose_gate_data: false, agent: codex, model: gpt-5.4, environment: docker, image: evolve-meta-agent-codex:20260805-codex0145, editable_roots: [target], prompt_path: target/src/minisweagent/config/mini.yaml, skills_dir: target/skills, memory_dir: target/memory, tools_dir: target/tools, max_retries: 1, timeout_s: 3600}
+  meta_agent: {variant: hyperagents, runner: harbor, expose_gate_data: false, agent: codex, model: gpt-5.4, environment: docker, image: evolve-meta-agent-codex:20260805-codex0145, editable_roots: [target], prompt_path: target/src/minisweagent/config/mini.yaml, skills_dir: target/skills, memory_dir: target/memory, max_retries: 1, timeout_s: 3600}
   gate: {variant: hillclimb}
   record: {variant: jsonl}
   timeout_s: 600

--- a/recipes/hill_climb_codex/evolve.yaml
+++ b/recipes/hill_climb_codex/evolve.yaml
@@ -16,7 +16,7 @@ operators:
   select: {variant: greedy}
   rollout: {variant: harbor, budget_tasks: 16, n_concurrent: 4, agent_setup_timeout_multiplier: 1, max_retries: 1, timeout_s: 3600}
   trace_analyzer: {variant: failure_patterns, max_chars: 30000, timeout_s: 600}
-  meta_agent: {variant: hyperagents, runner: harbor, expose_gate_data: false, agent: codex, model: gpt-5.4, environment: docker, image: evolve-meta-agent-codex:20260805-codex0145, editable_roots: [target], prompt_path: target/prompt.md, skills_dir: target/skills, memory_dir: target/memory, tools_dir: target/tools, max_retries: 1, timeout_s: 3600}
+  meta_agent: {variant: hyperagents, runner: harbor, expose_gate_data: false, agent: codex, model: gpt-5.4, environment: docker, image: evolve-meta-agent-codex:20260805-codex0145, editable_roots: [target], prompt_path: target/prompt.md, skills_dir: target/skills, memory_dir: target/memory, max_retries: 1, timeout_s: 3600}
   gate: {variant: hillclimb}
   record: {variant: jsonl}
   timeout_s: 600

--- a/recipes/hyperagents/evolve.yaml
+++ b/recipes/hyperagents/evolve.yaml
@@ -18,7 +18,7 @@ operators:
   select: {variant: score_child_prop, seed: 0}
   rollout: {variant: parent_evaluation, field_limit: 2000, timeout_s: 600}
   trace_analyzer: {variant: trace_browser, max_chars: 30000, timeout_s: 600}
-  meta_agent: {variant: hyperagents, runner: harbor, expose_gate_data: false, agent: evolve.integrations.harbor.miniswe_task_file:InstalledMiniSweAgent, model: openai/gpt-5.4-2026-03-05, environment: docker, image: evolve-meta-agent-app:20260724-tools-mswe245, editable_roots: [target, operators], prompt_path: target/src/minisweagent/config/mini.yaml, skills_dir: target/skills, memory_dir: target/memory, tools_dir: target/tools, agent_kwargs: {reasoning_effort: high, cost_limit: 0, max_tokens: 64000}, max_retries: 1, timeout_s: 21600}
+  meta_agent: {variant: hyperagents, runner: harbor, expose_gate_data: false, agent: evolve.integrations.harbor.miniswe_task_file:InstalledMiniSweAgent, model: openai/gpt-5.4-2026-03-05, environment: docker, image: evolve-meta-agent-app:20260724-tools-mswe245, editable_roots: [target, operators], prompt_path: target/src/minisweagent/config/mini.yaml, skills_dir: target/skills, memory_dir: target/memory, agent_kwargs: {reasoning_effort: high, cost_limit: 0, max_tokens: 64000}, max_retries: 1, timeout_s: 21600}
   validate: {variant: hyperagents, timeout_s: 300}
   gate: {variant: parent_eligible}
   record: {variant: hyperagents}

--- a/recipes/hyperagents_codex/evolve.yaml
+++ b/recipes/hyperagents_codex/evolve.yaml
@@ -16,7 +16,7 @@ operators:
   select: {variant: score_child_prop, seed: 0}
   rollout: {variant: parent_evaluation, field_limit: 2000, timeout_s: 600}
   trace_analyzer: {variant: trace_browser, max_chars: 30000, timeout_s: 600}
-  meta_agent: {variant: hyperagents, runner: harbor, expose_gate_data: false, agent: codex, model: gpt-5.4, environment: docker, image: evolve-meta-agent-codex:20260805-codex0145, editable_roots: [target, operators], prompt_path: target/prompt.md, skills_dir: target/skills, memory_dir: target/memory, tools_dir: target/tools, agent_kwargs: {reasoning_effort: high}, max_retries: 1, timeout_s: 21600}
+  meta_agent: {variant: hyperagents, runner: harbor, expose_gate_data: false, agent: codex, model: gpt-5.4, environment: docker, image: evolve-meta-agent-codex:20260805-codex0145, editable_roots: [target, operators], prompt_path: target/prompt.md, skills_dir: target/skills, memory_dir: target/memory, agent_kwargs: {reasoning_effort: high}, max_retries: 1, timeout_s: 21600}
   validate: {variant: hyperagents, timeout_s: 300}
   gate: {variant: parent_eligible}
   record: {variant: hyperagents}

--- a/tests/test_aevolve_meta_agent.py
+++ b/tests/test_aevolve_meta_agent.py
@@ -109,11 +109,9 @@ def _case(tmp_path: Path):
         "prompt_path": "target/prompt.md",
         "skills_dir": "target/skills",
         "memory_dir": "target/memory",
-        "tools_dir": "target/tools",
         "evolve_prompts": True,
         "evolve_skills": True,
         "evolve_memory": False,
-        "evolve_tools": False,
         "history_cycles": 2,
         "max_observations": 30,
         "feedback_chars": 300,
@@ -212,6 +210,9 @@ def test_aevolve_prompt_path_is_a_component_location_not_a_permission_boundary(t
     assert "Runtime prompt/config: `target/prompt.md`" in prompt
     assert "Skills evolution: disabled" in prompt
     assert "Review draft skills" not in prompt
+    assert "Candidate-owned tools" not in prompt
+    assert "Tools evolution" not in prompt
+    assert "- Tools:" not in prompt
     assert "Do not add standalone files to a disabled context layer" in prompt
 
 

--- a/tests/test_aevolve_recipe.py
+++ b/tests/test_aevolve_recipe.py
@@ -22,7 +22,6 @@ def test_aevolve_recipe_initializes_builtin_codex_workspace_contract(tmp_path: P
     assert "expose_gate_data: false" in config
     assert "runner: harbor" in config
     assert "evolve_memory: false" in config
-    assert "evolve_tools: false" in config
     assert "prompt_path: target/prompt.md" in config
     assert (workspace / "target" / "prompt.md").is_file()
     assert (workspace / "target" / "skills" / "task-execution" / "SKILL.md").is_file()

--- a/tests/test_phase_e_recipes.py
+++ b/tests/test_phase_e_recipes.py
@@ -72,6 +72,8 @@ def test_supported_recipes_use_harbor_and_method_meta_agent() -> None:
         assert "engine: harbor" in config
         assert "target/**" in config
         assert "target/agent.py" not in config
+        assert "tools_dir:" not in config
+        assert "evolve_tools:" not in config
         if name == "aevolve":
             assert f"dataset: {TERMINAL_BENCH_DATASET}" in config
             assert "seed: builtin-codex" in config
@@ -86,7 +88,6 @@ def test_supported_recipes_use_harbor_and_method_meta_agent() -> None:
             assert "evolve_prompts: true" in config
             assert "evolve_skills: true" in config
             assert "evolve_memory: false" in config
-            assert "evolve_tools: false" in config
             assert "agent: target.agent:HarborAgent" in config
         elif name == "gepa":
             assert f"dataset: {TERMINAL_BENCH_DATASET}" in config


### PR DESCRIPTION
## Summary

- remove `tools_dir` from all supported recipe configurations
- remove the unused `evolve_tools` A-Evolve switch
- stop advertising a nonexistent candidate-owned tools location in shared meta-agent workspace contracts
- keep prompt, skills, memory, mutation-surface, and runtime behavior unchanged
- add regression coverage for generated recipes and rendered A-Evolve prompts

## Why

EvolveX has no `target/tools` directories and no runtime path that loads, exposes, or invokes them. The existing fields only caused meta-agent prompts to advertise a runtime component that did not exist.

Candidate utilities remain supported as ordinary code within the mutable `target/` source tree when wired into the candidate runtime.

## Validation

- TDD regression confirmed the existing A-Evolve prompt exposed `Candidate-owned tools: target/tools`
- meta-agent prompt and recipe suites: 42 passed
- generated-workspace recipe composition and inventory suites: 26 passed
- Ruff lint and format checks on changed Python files: passed
- exact-reference scan and `git diff --check`: passed
