### PR TITLE
docs: normalize Trace Analyzer label

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ composable strategies for different agent-evolution scenarios.
 | [Recipes](recipes/README.md) | Supported evolution strategies. |
 | [Evaluation assets](evals/README.md) | Skill behavior/routing evaluation cases and result snapshots. |
 | [Meta-agents](docs/guides/meta-agents.md) | Trusted-host and isolated meta-agent runners. |
-| [`trace_analyzer`](docs/reference/operators/trace_analyzer.md) | Trace retention and analyzer variants. |
+| [Trace Analyzer](docs/reference/operators/trace_analyzer.md) | Trace retention and analyzer variants. |
 | [Local environment](docs/guides/local-environment.md) | Docker-free trusted local execution. |
 | [Operations](docs/guides/operations.md) | Doctor profiles, runtime setup, full-loop smoke, and recovery. |
 | [Contributing](CONTRIBUTING.md) | Development setup and repository conventions. |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,8 @@ edit_uri: edit/main/docs/
 
 theme:
   name: material
+  logo: evolve-mark.svg
+  favicon: evolve-mark.svg
   language: en
   features:
     - navigation.sections


### PR DESCRIPTION
## Summary

- make the Trace Analyzer entry in the README Documentation table use the same title-style presentation as the surrounding entries
- keep the link target and description unchanged

## Validation

- `UV_CACHE_DIR=/tmp/review-docs-uv-cache uv run --frozen pytest -q -n 0 tests/test_public_repository.py`
- `git diff --check`