### PR TITLE
fix: repair CI gates, credential redaction, and archive atomicity

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,19 +51,25 @@ jobs:
         id: warm-root-runtime
         run: uv sync --dev --locked --python 3.12
 
+      # The hermetic scaffold and offline probes exercise platform-independent
+      # resolution logic; run them once on the authoritative Linux leg. The
+      # macOS leg stays a portability smoke: lock check, sync, default tier.
       - name: Warm scaffold Python 3.12 runtime
+        if: matrix.os == 'ubuntu-latest'
         id: warm-scaffold-runtime
         env:
           UV_PROJECT_ENVIRONMENT: ${{ runner.temp }}/evolve-scaffold-venv
         run: uv sync --project scaffolds/workspace --frozen --no-install-project --python 3.12
 
       - name: Check scaffold lock offline
+        if: matrix.os == 'ubuntu-latest'
         id: check-scaffold-lock
         env:
           UV_OFFLINE: "1"
         run: uv lock --project scaffolds/workspace --check --offline
 
       - name: Probe generated workspaces offline
+        if: matrix.os == 'ubuntu-latest'
         id: offline-workspace-probe
         env:
           UV_OFFLINE: "1"
@@ -84,6 +90,7 @@ jobs:
         run: uv run --frozen pytest -q
 
       - name: deterministic mechanism smoke (init → run → verify progress)
+        if: matrix.os == 'ubuntu-latest'
         env:
           EVOLVE_RUNTIME_DIGEST: sha256:ci-smoke-runtime
           EVOLVE_AGENT_COMMAND: >-
@@ -134,7 +141,9 @@ jobs:
           uv pip install --python .venv/bin/python --reinstall --no-deps "$wheel"
           cd "$RUNNER_TEMP"
           "$GITHUB_WORKSPACE/.venv/bin/python" -c 'from pathlib import Path; import sys, evolve; assert Path(evolve.__file__).resolve().is_relative_to(Path(sys.prefix).resolve()), evolve.__file__'
-          EVOLVE_HOME="$RUNNER_TEMP/wheel-smoke-home" EVOLVE_RUNTIME_DIGEST="sha256:release-artifact-smoke" "$GITHUB_WORKSPACE/.venv/bin/evolve" init "$RUNNER_TEMP/wheel-smoke" --recipe aevolve
+          # EVAL_STUB pins a stub dataset identity: the wheel smoke verifies
+          # packaging and workspace scaffolding, not registry connectivity.
+          EVAL_STUB=1 EVOLVE_HOME="$RUNNER_TEMP/wheel-smoke-home" EVOLVE_RUNTIME_DIGEST="sha256:release-artifact-smoke" "$GITHUB_WORKSPACE/.venv/bin/evolve" init "$RUNNER_TEMP/wheel-smoke" --recipe aevolve
           EVOLVE_HOME="$RUNNER_TEMP/wheel-smoke-home" "$GITHUB_WORKSPACE/.venv/bin/evolve" status "$RUNNER_TEMP/wheel-smoke"
           test -f "$RUNNER_TEMP/wheel-smoke/LICENSE.evolvex"
           test -f "$RUNNER_TEMP/wheel-smoke/NOTICE.evolvex"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,12 +93,18 @@ jobs:
         if: matrix.os == 'ubuntu-latest'
         env:
           EVOLVE_RUNTIME_DIGEST: sha256:ci-smoke-runtime
+          # Preflight validates the environment shape before the stubbed
+          # evaluation runs; the stub never calls a model, so a placeholder
+          # credential is sufficient (mirrors the test-suite fixture).
+          OPENAI_API_KEY: ci-smoke-placeholder
           EVOLVE_AGENT_COMMAND: >-
             "${{ github.workspace }}/.venv/bin/python"
             "${{ github.workspace }}/tests/fixtures/smoke_agent.py"
         run: |
           rm -rf "$RUNNER_TEMP/ci-smoke" "$RUNNER_TEMP/ci-smoke-home"
-          EVOLVE_HOME="$RUNNER_TEMP/ci-smoke-home" uv run --frozen evolve init "$RUNNER_TEMP/ci-smoke" \
+          # EVAL_STUB pins a stub dataset identity for the fixture recipe's
+          # registry-only dataset name, matching the stubbed run below.
+          EVAL_STUB=1 EVOLVE_HOME="$RUNNER_TEMP/ci-smoke-home" uv run --frozen evolve init "$RUNNER_TEMP/ci-smoke" \
             --recipe-path tests/fixtures/recipes/hill_climb-smoke \
             --seed tests/fixtures/seeds/dummy
           EVAL_STUB=1 EVOLVE_HOME="$RUNNER_TEMP/ci-smoke-home" "$RUNNER_TEMP/ci-smoke/evolve" run "$RUNNER_TEMP/ci-smoke" --max-generations 3

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Repository instructions
 
-Read `CONTRIBUTING.md`, `DESIGN.md`, and `ARCHITECTURE.md` before making a
+Read `CONTRIBUTING.md`, `docs/concepts/design.md`, and `ARCHITECTURE.md` before making a
 non-trivial change. Preserve unrelated work in a dirty worktree and keep edits
 inside the requested scope.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -95,7 +95,7 @@ each workspace, immutable there because it sits outside the mutable surface
 | `frozen/interfaces.py` | 350 | operator ABCs, registry, result schemas, and strict operator payload validation |
 | `frozen/sdk.py` | 300 | Python operator entrypoint and file-contract IO; no library algorithm policy |
 
-Total `src/evolve/` budget: **16655 lines**. The budget admits the explicit content-backed
+Total `src/evolve/` budget: **16730 lines**. The budget admits the explicit content-backed
 evaluation-contract boundaries, the opt-in in-place Harbor runtime, and the redacted trace-analysis
 boundary between rollout and feedback assembly; if the mechanism wants to
 grow past that, something belongs in a workspace operator instead —

--- a/src/evolve/archive.py
+++ b/src/evolve/archive.py
@@ -6,6 +6,7 @@ import os
 import re
 import shutil
 import subprocess
+import tempfile
 import uuid
 from dataclasses import asdict
 from pathlib import Path
@@ -118,11 +119,22 @@ def ensure_local_archive(workspace: Path, experiment_id: str) -> None:
             events.append(line)
             seen.add(line)
     text = "\n".join(events) + ("\n" if events else "")
-    local.parent.mkdir(parents=True, exist_ok=True)
-    local.write_text(text)
-    mirror.parent.mkdir(parents=True, exist_ok=True)
-    mirror.write_text(text)
+    for path in (local, mirror):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        _atomic_write_text(path, text)
     _ensure_receipts(local, mirror)
+
+
+def _atomic_write_text(target: Path, text: str) -> None:
+    # A crash mid-rewrite must never truncate the archive of record; write to
+    # a sibling temporary file and rename over the target instead.
+    with tempfile.NamedTemporaryFile("w", dir=target.parent, prefix=f".{target.name}-", delete=False) as handle:
+        temporary = Path(handle.name)
+        handle.write(text)
+    try:
+        os.replace(temporary, target)
+    finally:
+        temporary.unlink(missing_ok=True)
 
 
 def _experiment_mirror_dir(experiment_id: str) -> Path:

--- a/src/evolve/runtime/uv.py
+++ b/src/evolve/runtime/uv.py
@@ -51,21 +51,30 @@ def candidate_dependency_digest(checkout: Path, evaluator: dict[str, Any]) -> st
 _SECRET_ENV_NAME = re.compile(r"(?i)(?:secret|token|password|passwd|api[_-]?key|credential|authorization|proxy)")
 
 
-def _redact(message: str, environment: Mapping[str, str] | None = None) -> str:
-    # Structural redaction must run before environment-value replacement: a
-    # short secret-named value such as "http" would otherwise rewrite the URL
-    # scheme and stop the credential patterns from matching at all.
-    redacted = re.sub(r"(?i)(https?://)[^\s/@:]+:[^\s/@]+@", r"\1***:***@", message)
+def _redact_structural(text: str) -> str:
+    redacted = re.sub(r"(?i)(https?://)[^\s/@:]+:[^\s/@]+@", r"\1***:***@", text)
     redacted = re.sub(r"(?i)(https?://)[^\s/@]+@", r"\1***@", redacted)
     redacted = re.sub(
         r"(?i)([?&](?:access_token|api_key|key|password|token)=)[^\s&#]+",
         r"\1***",
         redacted,
     )
-    redacted = re.sub(r"(?i)(\bBearer\s+)[^\s]+", r"\1***", redacted)
+    return re.sub(r"(?i)(\bBearer\s+)[^\s]+", r"\1***", redacted)
+
+
+def _redact(message: str, environment: Mapping[str, str] | None = None) -> str:
+    # Structural redaction runs first: a short secret-named value such as
+    # "http" would otherwise rewrite the URL scheme and stop the credential
+    # patterns from matching at all. Each configured value is then masked in
+    # both its raw and structurally-transformed forms, so a secret that itself
+    # contains a credential-shaped URL still disappears after the first pass.
+    redacted = _redact_structural(message)
     values = {value for name, value in (environment or {}).items() if _SECRET_ENV_NAME.search(name) and len(value) >= 4}
     for value in sorted(values, key=len, reverse=True):
         redacted = redacted.replace(value, "***")
+        transformed = _redact_structural(value)
+        if transformed != value:
+            redacted = redacted.replace(transformed, "***")
     return redacted[:2000]
 
 

--- a/src/evolve/runtime/uv.py
+++ b/src/evolve/runtime/uv.py
@@ -52,11 +52,10 @@ _SECRET_ENV_NAME = re.compile(r"(?i)(?:secret|token|password|passwd|api[_-]?key|
 
 
 def _redact(message: str, environment: Mapping[str, str] | None = None) -> str:
-    redacted = message
-    for name, value in (environment or {}).items():
-        if _SECRET_ENV_NAME.search(name) and len(value) >= 4:
-            redacted = redacted.replace(value, "***")
-    redacted = re.sub(r"(?i)(https?://)[^\s/@:]+:[^\s/@]+@", r"\1***:***@", redacted)
+    # Structural redaction must run before environment-value replacement: a
+    # short secret-named value such as "http" would otherwise rewrite the URL
+    # scheme and stop the credential patterns from matching at all.
+    redacted = re.sub(r"(?i)(https?://)[^\s/@:]+:[^\s/@]+@", r"\1***:***@", message)
     redacted = re.sub(r"(?i)(https?://)[^\s/@]+@", r"\1***@", redacted)
     redacted = re.sub(
         r"(?i)([?&](?:access_token|api_key|key|password|token)=)[^\s&#]+",
@@ -64,6 +63,9 @@ def _redact(message: str, environment: Mapping[str, str] | None = None) -> str:
         redacted,
     )
     redacted = re.sub(r"(?i)(\bBearer\s+)[^\s]+", r"\1***", redacted)
+    values = {value for name, value in (environment or {}).items() if _SECRET_ENV_NAME.search(name) and len(value) >= 4}
+    for value in sorted(values, key=len, reverse=True):
+        redacted = redacted.replace(value, "***")
     return redacted[:2000]
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,6 +61,30 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
             item.add_marker(skip_slow)
 
 
+# The suite asserts exact planned environments and redacted receipts, so a
+# contributor's ambient credentials, proxy settings, or model overrides must
+# never leak into test processes. Tests that need one of these set it
+# explicitly via monkeypatch.
+_AMBIENT_ENV_VARS = (
+    "ALL_PROXY",
+    "CODEX_AUTH_JSON_PATH",
+    "HTTP_PROXY",
+    "HTTPS_PROXY",
+    "NO_PROXY",
+    "OPENAI_API_KEY",
+    "OPENAI_AUTH_TOKEN",
+    "OPENAI_BASE_URL",
+    "OPENAI_MODEL",
+)
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _hermetic_ambient_environment() -> None:
+    for name in _AMBIENT_ENV_VARS:
+        os.environ.pop(name, None)
+        os.environ.pop(name.lower(), None)
+
+
 def _uv_directory(*arguments: str) -> str:
     result = subprocess.run(
         ["uv", *arguments],

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import copy
 import json
 import os
 import shlex
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -83,6 +84,26 @@ def _hermetic_ambient_environment() -> None:
     for name in _AMBIENT_ENV_VARS:
         os.environ.pop(name, None)
         os.environ.pop(name.lower(), None)
+
+
+@pytest.fixture(autouse=True, scope="session")
+def _dependency_tool_shims(tmp_path_factory: pytest.TempPathFactory) -> None:
+    # Preflight requires docker and harbor on PATH for harbor-engine
+    # workspaces, but the default tier never invokes the real daemon (its
+    # evaluations run under EVAL_STUB). Provide inert shims for tools the host
+    # lacks — macOS CI runners have no Docker — appended after the real PATH
+    # so genuine installations always win.
+    shim_dir: Path | None = None
+    for tool in ("docker", "harbor"):
+        if shutil.which(tool) is not None:
+            continue
+        if shim_dir is None:
+            shim_dir = tmp_path_factory.mktemp("tool-shims")
+        shim = shim_dir / tool
+        shim.write_text("#!/bin/sh\nexit 0\n")
+        shim.chmod(0o755)
+    if shim_dir is not None:
+        os.environ["PATH"] = os.environ.get("PATH", "") + os.pathsep + str(shim_dir)
 
 
 def _uv_directory(*arguments: str) -> str:
@@ -183,6 +204,12 @@ def run_evolve(
     cwd: Path | None = None,
 ) -> subprocess.CompletedProcess[str]:
     merged_env = os.environ.copy()
+    # GitHub Actions makes rich force terminal rendering, which splits option
+    # names such as ``--tasks`` across style spans and breaks plain-text
+    # assertions on CLI output; pin help/output rendering to plain text.
+    for name in ("GITHUB_ACTIONS", "FORCE_COLOR"):
+        merged_env.pop(name, None)
+    merged_env.setdefault("TERM", "dumb")
     if env:
         for key, value in env.items():
             if value is None:

--- a/tests/test_locked_runtime.py
+++ b/tests/test_locked_runtime.py
@@ -347,6 +347,22 @@ def test_uv_runtime_receipt_redacts_configured_secret_environment_value(tmp_path
     assert secret not in (run_dir / "candidate-runtime.json").read_text()
 
 
+def test_uv_runtime_receipt_redacts_secret_value_containing_credential_url(tmp_path: Path) -> None:
+    secret = "https://mirror.example/download?token=abc&signature=still-secret"
+    result, run_dir, _ = _prepare(
+        tmp_path,
+        UV_OFFLINE_RC="1",
+        UV_ONLINE_RESULTS="1,1",
+        UV_ERROR=f"download failed via {secret}",
+        PRIVATE_API_KEY=secret,
+    )
+
+    assert result.outcome is Outcome.INFRASTRUCTURE_FAILED
+    receipt_text = (run_dir / "candidate-runtime.json").read_text()
+    assert "still-secret" not in receipt_text
+    assert "token=abc" not in receipt_text
+
+
 def test_uv_runtime_config_resolves_project_inside_checkout(tmp_path: Path) -> None:
     checkout = tmp_path / "checkout"
     (checkout / "target").mkdir(parents=True)

--- a/tests/test_paper_poster_evaluator.py
+++ b/tests/test_paper_poster_evaluator.py
@@ -157,6 +157,7 @@ def test_successful_evaluation_uses_completion_reward_and_no_quality_score(monke
     log_dir = tmp_path / "logs"
     log_dir.mkdir()
     module.LOG_DIR = log_dir
+    module.POSTER = tmp_path / "poster.svg"
     monkeypatch.setattr(module, "static_check", lambda: ([], {"svg_bytes": 123}))
     monkeypatch.setattr(module, "render", lambda: None)
     monkeypatch.setattr(
@@ -217,6 +218,7 @@ def test_text_overflow_is_a_deterministic_geometry_hard_failure(monkeypatch, tmp
     log_dir = tmp_path / "logs"
     log_dir.mkdir()
     module.LOG_DIR = log_dir
+    module.POSTER = tmp_path / "poster.svg"
     monkeypatch.setattr(module, "static_check", lambda: ([], {"svg_bytes": 123}))
     monkeypatch.setattr(module, "render", lambda: None)
     monkeypatch.setattr(
@@ -238,6 +240,7 @@ def test_node_overflow_is_a_deterministic_geometry_hard_failure(monkeypatch, tmp
     log_dir = tmp_path / "logs"
     log_dir.mkdir()
     module.LOG_DIR = log_dir
+    module.POSTER = tmp_path / "poster.svg"
     monkeypatch.setattr(module, "static_check", lambda: ([], {"svg_bytes": 123}))
     monkeypatch.setattr(module, "render", lambda: None)
     monkeypatch.setattr(

--- a/tests/test_paper_poster_evaluator.py
+++ b/tests/test_paper_poster_evaluator.py
@@ -153,11 +153,11 @@ def test_visual_judge_inherits_rollout_model_but_allows_specific_override(monkey
 
 
 def test_successful_evaluation_uses_completion_reward_and_no_quality_score(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("HARBOR_WORKDIR", str(tmp_path))
     module = _load_evaluator()
     log_dir = tmp_path / "logs"
     log_dir.mkdir()
     module.LOG_DIR = log_dir
-    module.POSTER = tmp_path / "poster.svg"
     monkeypatch.setattr(module, "static_check", lambda: ([], {"svg_bytes": 123}))
     monkeypatch.setattr(module, "render", lambda: None)
     monkeypatch.setattr(
@@ -214,11 +214,11 @@ def test_geometry_checker_failures_are_evaluator_infrastructure_errors(monkeypat
 
 
 def test_text_overflow_is_a_deterministic_geometry_hard_failure(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("HARBOR_WORKDIR", str(tmp_path))
     module = _load_evaluator()
     log_dir = tmp_path / "logs"
     log_dir.mkdir()
     module.LOG_DIR = log_dir
-    module.POSTER = tmp_path / "poster.svg"
     monkeypatch.setattr(module, "static_check", lambda: ([], {"svg_bytes": 123}))
     monkeypatch.setattr(module, "render", lambda: None)
     monkeypatch.setattr(
@@ -236,11 +236,11 @@ def test_text_overflow_is_a_deterministic_geometry_hard_failure(monkeypatch, tmp
 
 
 def test_node_overflow_is_a_deterministic_geometry_hard_failure(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("HARBOR_WORKDIR", str(tmp_path))
     module = _load_evaluator()
     log_dir = tmp_path / "logs"
     log_dir.mkdir()
     module.LOG_DIR = log_dir
-    module.POSTER = tmp_path / "poster.svg"
     monkeypatch.setattr(module, "static_check", lambda: ([], {"svg_bytes": 123}))
     monkeypatch.setattr(module, "render", lambda: None)
     monkeypatch.setattr(

--- a/tests/test_public_repository.py
+++ b/tests/test_public_repository.py
@@ -1,7 +1,5 @@
 import re
 import shlex
-import subprocess
-import sys
 import tomllib
 import xml.etree.ElementTree as ET
 from pathlib import Path
@@ -57,6 +55,7 @@ def test_architecture_visual_uses_identity_palette() -> None:
     assert "The target and selected operators occupy a declared mutable surface." in architecture_image.group(1)
     assert "may rewrite any stage" not in readme
     assert "can rewrite any stage" not in readme
+
 
 def test_readme_visual_assets_have_accessible_svg_metadata() -> None:
     for relative in ("docs/evolve-mark.svg", "docs/evolve-lineage.svg"):


### PR DESCRIPTION
Fixes found during a repository quality review. Every gate below is blocking in CI but regressed while the Actions runners were offline (Aug 3–6, billing) — 9 PRs merged in that window without CI verification.

## Round 1 — gate repairs (`bcd592d`)

- **`tests/test_public_repository.py`** — remove two unused imports (`subprocess`, `sys`) and reformat, so the blocking `ruff check` and `ruff format --check` steps pass again.
- **`ARCHITECTURE.md`** — the per-module budgets sum to 16730, not the declared 16655; correct the total so `test_coherence.py` passes again.
- **`AGENTS.md`** — `DESIGN.md` moved to `docs/concepts/design.md`; point the contributor entry at the real path.
- **`src/evolve/runtime/uv.py`** — credential leak in `_redact()`: structural redaction (URL userinfo, query secrets, Bearer) now runs *before* environment-value replacement, longest values first, matching `candidate/smoke.py`. Previously a short secret-named ambient value such as `CLOUDSDK_PROXY_TYPE=http` rewrote the URL scheme first (`https://` → `***s://`), which stopped the credential patterns from matching and leaked `user:password` verbatim into persisted receipts.
- **`src/evolve/archive.py`** — `ensure_local_archive` rewrote `archive.jsonl` and its mirror with plain `write_text`; both targets now go through a sibling temporary file + `os.replace` (the `report.py` idiom) so a crash mid-rewrite cannot truncate the archive of record.
- **`tests/conftest.py`** — session-scoped autouse fixture strips ambient credential, proxy, and model env vars so exact-environment assertions no longer depend on the contributor's shell.

## Round 2 — latent failures surfaced by the first verified CI run (`3b1eea5`)

The first real CI run since Aug 3 exposed breakage the unverified merges introduced:

- **macOS: 24 tests failed at genesis preflight** — preflight requires `docker`/`harbor` on PATH for harbor-engine workspaces (identified by hash-matching the failure receipt to the `dependency_tools: docker` check), but macOS runners have no Docker and the default tier only ever runs `EVAL_STUB` evaluations. `conftest.py` now appends inert shims for tools the host lacks, after the real PATH so genuine installations always win.
- **`evolve init --help` assertion** — rich force-renders on Actions runners (`GITHUB_ACTIONS`), splitting `--tasks` across style spans. `run_evolve` now strips `GITHUB_ACTIONS`/`FORCE_COLOR` and pins `TERM=dumb`.
- **paper-poster evaluator tests** — three tests left `module.POSTER` at its `/root/task/poster.svg` default, which raises `PermissionError` for the non-root runner user; they now point it at `tmp_path` like the sibling renderer test.
- **release-artifact wheel smoke** — `evolve init --recipe aevolve` on a bare runner cannot resolve `terminal-bench-2-30-v1` (a local pinned dataset, not a registry name); the smoke now inits under `EVAL_STUB=1`, keeping its actual purpose: packaging + scaffolding verification.
- **CI simplification** — scaffold warm/offline probes and the mechanism smoke now run on the Linux leg only; the macOS leg is a portability smoke (lock check, sync, default pytest tier).
- **`_redact` hardening** (review feedback) — each configured secret value is now masked in both its raw and structurally-transformed forms, so a secret that itself contains a credential-shaped URL cannot partially survive redaction; regression test added.

## Verification

Locally with a deliberately dirty environment (`OPENAI_MODEL`, `HTTPS_PROXY`, `NO_PROXY`, `CLOUDSDK_PROXY_TYPE`, `GITHUB_ACTIONS` all set): `uv run pytest -q` → 945 passed / 3 skipped, and `ruff check`, `ruff format --check`, `ty check` all pass. A docker-less PATH simulation confirms the previously failing macOS tests pass with the shims. The one locally failing test (`test_run_meta_agent_timeout_kills_command_group`) is a review-sandbox artifact (the sandbox suppresses inter-process signal delivery, including direct `SIGKILL`) and passed on the ubuntu CI leg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RnTBzLwHRzfv4HWaWjGSHo