### PR TITLE
Fix Harbor task IDs and timed-out container cleanup

### DIFF
--- a/library/meta_agent/runners/harbor.py
+++ b/library/meta_agent/runners/harbor.py
@@ -871,6 +871,63 @@ def _run_timeout() -> float | None:
     return max(0.1, outer - min(5.0, max(0.5, outer * 0.05)))
 
 
+def _harbor_compose_projects(command: list[str]) -> list[str]:
+    try:
+        jobs_root = Path(command[command.index("--jobs-dir") + 1])
+    except (ValueError, IndexError):
+        return []
+    try:
+        job_name = command[command.index("--job-name") + 1]
+    except (ValueError, IndexError):
+        job_name = ""
+    search_root = jobs_root / job_name if job_name else jobs_root
+    projects: set[str] = set()
+    for config_path in search_root.rglob("config.json"):
+        payload = _read_json(config_path)
+        trial_name = payload.get("trial_name") if isinstance(payload, dict) else None
+        if isinstance(trial_name, str) and trial_name:
+            projects.add(re.sub(r"[^a-z0-9_-]", "-", f"{trial_name}__env".lower()))
+    return sorted(projects)
+
+
+def _cleanup_harbor_containers(command: list[str], env: dict[str, str]) -> list[str]:
+    messages: list[str] = []
+    for project in _harbor_compose_projects(command):
+        try:
+            query = subprocess.run(
+                ["docker", "ps", "-aq", "--filter", f"label=com.docker.compose.project={project}"],
+                env=env,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+        except OSError as exc:
+            messages.append(f"cleanup query failed for {project}: {exc.__class__.__name__}")
+            continue
+        if query.returncode != 0:
+            messages.append(f"cleanup query failed for {project}: exit {query.returncode}")
+            continue
+        container_ids = [line.strip() for line in query.stdout.splitlines() if line.strip()]
+        if not container_ids:
+            continue
+        try:
+            removed = subprocess.run(
+                ["docker", "rm", "-f", *container_ids],
+                env=env,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+        except OSError as exc:
+            messages.append(f"cleanup remove failed for {project}: {exc.__class__.__name__}")
+            continue
+        if removed.returncode == 0:
+            messages.append(f"cleaned timed-out Harbor project {project}")
+        else:
+            messages.append(f"cleanup remove failed for {project}: exit {removed.returncode}")
+    return messages
+
+
 def _run_harbor(
     command: list[str],
     checkout: Path,
@@ -916,6 +973,9 @@ def _run_harbor(
                 process.kill()
             process.wait()
         chunks.append("\nharbor meta-agent timed out\n")
+        cleanup_messages = _cleanup_harbor_containers(command, env)
+        if cleanup_messages:
+            chunks.append("\n".join(cleanup_messages) + "\n")
     reader.join()
     wall_s = round(time.monotonic() - start, 6)
     log_path.parent.mkdir(parents=True, exist_ok=True)

--- a/library/meta_agent/runners/harbor.py
+++ b/library/meta_agent/runners/harbor.py
@@ -262,7 +262,14 @@ def _copy_visible_generation_inputs(source: Path, destination: Path) -> None:
         subtree = source / name
         if subtree.exists():
             copied = destination / name
-            _copy_tree(subtree, copied)
+            # trajectory_only uses isolated Harbor jobs to produce the
+            # published evidence bundle. Those jobs are implementation
+            # artifacts, not meta-agent evidence, and may contain the judge
+            # model's unrelated context (including names that overlap private
+            # task partitions). Only the analyzer's published outputs belong
+            # in the editing bundle.
+            ignore = shutil.ignore_patterns("judge") if name == "trace_analyzer" else None
+            _copy_tree(subtree, copied, ignore=ignore)
             # Certified replay snapshots are intentionally frozen in the
             # experiment workspace. Docker Compose's artifact copier preserves
             # those directory modes, then cannot create their descendants in

--- a/recipes/aevolve/README.md
+++ b/recipes/aevolve/README.md
@@ -28,10 +28,9 @@ The mapping is:
 | Git snapshots | generation tags |
 | holdout validation | disjoint gate split plus strict hill-climb gate |
 
-The full SkillForge orchestration still has optional capabilities that this
-recipe does not claim to reproduce:
+Current scope limitations:
 
-- upstream's reference judge is hard-wired to a Bedrock model; this recipe
+- the reference judge is hard-wired to a Bedrock model; this recipe
   invokes the configured meta-agent model through Harbor with the same
   behavior-only input and verdict schema;
 - the solver cannot currently return newly proposed draft skills into

--- a/recipes/aevolve/README.md
+++ b/recipes/aevolve/README.md
@@ -28,9 +28,9 @@ The mapping is:
 | Git snapshots | generation tags |
 | holdout validation | disjoint gate split plus strict hill-climb gate |
 
-Current scope limitations:
+Differences from the A-Evolve reference implementation:
 
-- the reference judge is hard-wired to a Bedrock model; this recipe
+- the reference implementation's judge is hard-wired to a Bedrock model; this recipe
   invokes the configured meta-agent model through Harbor with the same
   behavior-only input and verdict schema;
 - the solver cannot currently return newly proposed draft skills into

--- a/seeds/codex/agent.py
+++ b/seeds/codex/agent.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
 import shlex
 import tomllib
+import uuid
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
@@ -20,6 +22,7 @@ PLUGIN_NAME = "evolve-target"
 PLUGIN_MARKETPLACE = "evolve-target"
 AUTH_MODE_ENV = "EVOLVE_CODEX_AUTH_MODE"
 AUTH_MODES = ("auto", "api", "auth_json")
+AGENT_RUN_ENV = "EVOLVE_CODEX_AGENT_RUN_ID"
 
 
 def _target_root(extra_env: object) -> Path:
@@ -176,13 +179,62 @@ class HarborAgent(Codex):
         marker = "codex exec "
         if marker in command and "--dangerously-bypass-hook-trust" not in command:
             command = command.replace(marker, marker + "--dangerously-bypass-hook-trust ", 1)
-        return await super().exec_as_agent(
-            environment,
-            command=command,
-            env=env,
-            cwd=cwd,
-            timeout_sec=timeout_sec,
-        )
+        if marker not in command:
+            return await super().exec_as_agent(
+                environment,
+                command=command,
+                env=env,
+                cwd=cwd,
+                timeout_sec=timeout_sec,
+            )
+
+        run_id = uuid.uuid4().hex
+        command = f"export {AGENT_RUN_ENV}={run_id}; {command}"
+        try:
+            return await super().exec_as_agent(
+                environment,
+                command=command,
+                env=env,
+                cwd=cwd,
+                timeout_sec=timeout_sec,
+            )
+        except asyncio.CancelledError:
+            await self._cleanup_cancelled_run(environment, run_id)
+            raise
+
+    async def _cleanup_cancelled_run(
+        self,
+        environment: BaseEnvironment,
+        run_id: str,
+    ) -> None:
+        marker = shlex.quote(f"{AGENT_RUN_ENV}={run_id}")
+        command = f"""
+marker={marker}
+pids=
+for envfile in /proc/[0-9]*/environ; do
+  [ -r "$envfile" ] || continue
+  if tr '\\000' '\\n' <"$envfile" 2>/dev/null | grep -Fqx -- "$marker"; then
+    pid=${{envfile#/proc/}}
+    pid=${{pid%/environ}}
+    [ "$pid" = "$$" ] || pids="$pids $pid"
+  fi
+done
+if [ -n "$pids" ]; then
+  kill -TERM $pids 2>/dev/null || true
+  sleep 1
+  kill -KILL $pids 2>/dev/null || true
+fi
+""".strip()
+        try:
+            await asyncio.shield(
+                super().exec_as_agent(
+                    environment,
+                    command=command,
+                    timeout_sec=10,
+                )
+            )
+        except Exception:
+            pass
 
     async def setup(self, environment: BaseEnvironment) -> None:
         await super().setup(environment)

--- a/src/evolve/evaluation/diagnostics.py
+++ b/src/evolve/evaluation/diagnostics.py
@@ -120,7 +120,11 @@ def materialize_missing_trials(
 def _normalize_harbor_task_id(trial: TrialResult, expected_task_ids: set[str]) -> TrialResult:
     if trial.task_id in expected_task_ids:
         return trial
-    matches = [task_id for task_id in expected_task_ids if trial.task_id.endswith(f"__{task_id}")]
+    matches = [
+        task_id
+        for task_id in expected_task_ids
+        if trial.task_id.endswith(f"__{task_id}") or trial.task_id.endswith(f"/{task_id}")
+    ]
     return replace(trial, task_id=matches[0]) if len(matches) == 1 else trial
 
 

--- a/tests/test_evaluation_diagnostics.py
+++ b/tests/test_evaluation_diagnostics.py
@@ -70,6 +70,25 @@ def test_materialize_missing_trials_accepts_unique_harbor_task_suffix() -> None:
     ]
 
 
+def test_materialize_missing_trials_accepts_unique_harbor_dataset_namespace() -> None:
+    expected = (TrialIdentity("task-a", 0, False, None),)
+    observed = (
+        TrialResult(
+            "terminal-bench/task-a",
+            0,
+            Outcome.BENCHMARK_COMPLETE,
+            1.0,
+            "benchmark",
+        ),
+    )
+
+    trials = materialize_missing_trials(expected, observed)
+
+    assert [(trial.task_id, trial.outcome) for trial in trials] == [
+        ("task-a", Outcome.BENCHMARK_COMPLETE),
+    ]
+
+
 def test_materialize_missing_trials_rejects_ambiguous_harbor_task_suffix() -> None:
     expected = (
         TrialIdentity("task-a", 0, False, None),
@@ -89,6 +108,27 @@ def test_materialize_missing_trials_rejects_ambiguous_harbor_task_suffix() -> No
 
     assert [trial.outcome for trial in trials[:2]] == [Outcome.MISSING, Outcome.MISSING]
     assert trials[2].task_id == "registry__dataset__task-a"
+
+
+def test_materialize_missing_trials_rejects_ambiguous_harbor_dataset_namespace() -> None:
+    expected = (
+        TrialIdentity("task-a", 0, False, None),
+        TrialIdentity("dataset/task-a", 0, False, None),
+    )
+    observed = (
+        TrialResult(
+            "registry/dataset/task-a",
+            0,
+            Outcome.BENCHMARK_COMPLETE,
+            1.0,
+            "benchmark",
+        ),
+    )
+
+    trials = materialize_missing_trials(expected, observed)
+
+    assert [trial.outcome for trial in trials[:2]] == [Outcome.MISSING, Outcome.MISSING]
+    assert trials[2].task_id == "registry/dataset/task-a"
 
 
 def _mixed_record() -> EvaluationRecord:

--- a/tests/test_harbor_meta_agent.py
+++ b/tests/test_harbor_meta_agent.py
@@ -1250,6 +1250,37 @@ def test_harbor_bundle_rejects_private_task_identifiers(tmp_path: Path, leak_sou
         )
 
 
+def test_harbor_bundle_omits_trajectory_judge_workdirs(tmp_path: Path) -> None:
+    checkout, run_dir = _checkout(tmp_path)
+    evaluator = checkout / "evaluator"
+    evaluator.mkdir()
+    (evaluator / "splits.json").write_text(
+        json.dumps({"tasks": {"train": ["train-task"], "gate": ["gate-secret-task"], "sealed": []}})
+    )
+    evidence = run_dir / "trace_analyzer" / "evidence"
+    evidence.mkdir(parents=True, exist_ok=True)
+    (evidence / "trajectory_only.json").write_text('[{"task_id":"train-task"}]\n')
+    judge = run_dir / "trace_analyzer" / "judge" / "0000-task" / "attempt-1"
+    judge.mkdir(parents=True)
+    (judge / "agent-context.jsonl").write_text('{"unrelated_context":"gate-secret-task"}\n')
+    runner = _harbor_runner_module()
+    surface = runner.load_surface_policy(checkout)
+
+    bundle = runner._prepare_bundle(
+        checkout,
+        _ctx(checkout, run_dir),
+        ["target"],
+        surface,
+        prompt="analyze train-task",
+    )
+    try:
+        copied = bundle.workspace / "runs" / "gen-1" / "trace_analyzer"
+        assert (copied / "evidence" / "trajectory_only.json").is_file()
+        assert not (copied / "judge").exists()
+    finally:
+        shutil.rmtree(bundle.staging, ignore_errors=True)
+
+
 def test_harbor_bundle_allows_private_name_prefix_in_training_identifier(tmp_path: Path) -> None:
     checkout, run_dir = _checkout(tmp_path)
     evaluator = checkout / "evaluator"

--- a/tests/test_harbor_meta_agent.py
+++ b/tests/test_harbor_meta_agent.py
@@ -174,6 +174,54 @@ def test_harbor_meta_agent_child_creates_private_files(tmp_path: Path) -> None:
     assert stat.S_IMODE(log.stat().st_mode) == 0o600
 
 
+def test_harbor_timeout_removes_only_its_compose_project(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module = _harbor_runner_module()
+    jobs = tmp_path / "jobs"
+    trial = jobs / "readonly-job" / "readonly-trial"
+    trial.mkdir(parents=True)
+    (trial / "config.json").write_text(json.dumps({"trial_name": "Readonly-Trial__AbC123"}))
+    docker_calls: list[list[str]] = []
+
+    def fake_run(command, **_kwargs):
+        docker_calls.append(command)
+        if command[1:3] == ["ps", "-aq"]:
+            return SimpleNamespace(returncode=0, stdout="container-id\n", stderr="")
+        return SimpleNamespace(returncode=0, stdout="container-id\n", stderr="")
+
+    monkeypatch.setattr(module.subprocess, "run", fake_run)
+    returncode, _wall_s = module._run_harbor(
+        [
+            "/bin/sh",
+            "-c",
+            "sleep 30",
+            "--jobs-dir",
+            str(jobs),
+            "--job-name",
+            "readonly-job",
+        ],
+        tmp_path,
+        tmp_path / "harbor.log",
+        dict(os.environ),
+        timeout_s=0.05,
+    )
+
+    assert returncode != 0
+    assert docker_calls == [
+        [
+            "docker",
+            "ps",
+            "-aq",
+            "--filter",
+            "label=com.docker.compose.project=readonly-trial__abc123__env",
+        ],
+        ["docker", "rm", "-f", "container-id"],
+    ]
+    assert "cleaned timed-out Harbor project readonly-trial__abc123__env" in (tmp_path / "harbor.log").read_text()
+
+
 def test_codex_harbor_process_cannot_fall_back_to_host_openai_environment(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_m7_codex_seed.py
+++ b/tests/test_m7_codex_seed.py
@@ -155,7 +155,8 @@ def test_builtin_codex_wrapper_injects_skills_and_opt_in_compaction(tmp_path: Pa
     assert "codex plugin marketplace add /tmp/evolve-target-marketplace" in registration
     assert "codex plugin add evolve-target@evolve-target" in registration
     rewritten = asyncio.run(agent.exec_as_agent(environment, "codex exec --json -- task"))
-    assert rewritten == "codex exec --dangerously-bypass-hook-trust --json -- task"
+    assert rewritten.startswith("export EVOLVE_CODEX_AGENT_RUN_ID=")
+    assert rewritten.endswith("codex exec --dangerously-bypass-hook-trust --json -- task")
     unchanged = asyncio.run(agent.exec_as_agent(environment, "codex plugin list"))
     assert unchanged == "codex plugin list"
 
@@ -219,6 +220,53 @@ def test_builtin_codex_wrapper_injects_skills_and_opt_in_compaction(tmp_path: Pa
     assert compacting_agent.kwargs["auto_compact_token_limit"] == 100000
     assert compacting_agent.kwargs["auto_compact_token_limit_scope"] == "total"
     assert compacting_agent.kwargs["tool_output_token_limit"] == 12000
+
+
+def test_builtin_codex_wrapper_cleans_processes_after_cancellation(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    _install_fake_harbor(monkeypatch)
+    module = _load_target_agent(Path(__file__).parents[1] / "seeds" / "codex" / "agent.py")
+    calls: list[tuple[str, int | None]] = []
+
+    async def cancelling_exec(
+        self,
+        environment: object,
+        command: str,
+        env: dict[str, str] | None = None,
+        cwd: str | None = None,
+        timeout_sec: int | None = None,
+    ) -> str:
+        del self, environment, env, cwd
+        calls.append((command, timeout_sec))
+        if len(calls) == 1:
+            try:
+                await asyncio.sleep(3600)
+            except asyncio.CancelledError:
+                await asyncio.sleep(0)
+                raise
+        return command
+
+    monkeypatch.setattr(FakeCodex, "exec_as_agent", cancelling_exec)
+    agent = module.HarborAgent(logs_dir=tmp_path / "logs")
+
+    with pytest.raises(TimeoutError):
+        asyncio.run(
+            asyncio.wait_for(
+                agent.exec_as_agent(object(), "codex exec --json -- task"),
+                timeout=0.01,
+            )
+        )
+
+    launch, cleanup = calls
+    assert launch[0].startswith("export EVOLVE_CODEX_AGENT_RUN_ID=")
+    run_id = launch[0].split(";", 1)[0].split("=", 1)[1]
+    assert f"marker=EVOLVE_CODEX_AGENT_RUN_ID={run_id}" in cleanup[0]
+    assert "/proc/[0-9]*/environ" in cleanup[0]
+    assert "kill -TERM $pids" in cleanup[0]
+    assert "kill -KILL $pids" in cleanup[0]
+    assert cleanup[1] == 10
 
 
 def test_builtin_codex_seed_contains_valid_plugin_layout() -> None:


### PR DESCRIPTION
## Summary

- normalize Harbor dataset task IDs before materializing tasks
- keep trajectory-judge internals out of the meta-agent bundle
- clean up timed-out Harbor meta-agent containers
- terminate cancelled Codex task processes
- clarify differences from the A-Evolve reference implementation

## Validation

- `26 passed` for the focused test suite after reverting the proposed GEPA timeout-scoring behavior change
- live Terminal-Bench 2 A-Evolve and GEPA runs have exercised the Harbor task-ID and cleanup paths

## Notes

This PR intentionally preserves the existing GEPA unscorable-error semantics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cleanup of timed-out Harbor tasks and canceled Codex runs by removing related containers and processes.
  - Excluded judge-only directories from visible trace-analysis inputs while preserving required evidence.
  - Improved Harbor task identification for namespaced dataset paths.
  - Prevented cleanup from affecting unrelated trials.

- **Documentation**
  - Updated the A-Evolve recipe documentation to clarify its reference implementation limitations.

- **Tests**
  - Added coverage for timeout cleanup, input preparation, task normalization, and canceled-run process termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->