### PR TITLE
fix: harden Harbor evidence and timeout handling

### DIFF
--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -150,6 +150,25 @@ UV_CACHE_DIR=/data/uv-cache
 TMPDIR=/data/evolve/tmp
 ```
 
+## Harbor execution headroom
+
+Harbor timeout multipliers are optional execution controls. Each multiplier is
+applied to the corresponding limit declared by a benchmark task; it does not
+replace the task's timeout:
+
+| Variable | Purpose |
+| --- | --- |
+| `EVOLVE_HARBOR_AGENT_SETUP_TIMEOUT_MULTIPLIER` | agent installation/setup headroom |
+| `EVOLVE_HARBOR_AGENT_TIMEOUT_MULTIPLIER` | target-agent execution headroom |
+| `EVOLVE_HARBOR_VERIFIER_TIMEOUT_MULTIPLIER` | verifier execution headroom |
+| `EVOLVE_HARBOR_MAX_RETRIES` | Harbor retry count for retry-eligible exceptions |
+| `EVOLVE_HARBOR_N_CONCURRENT` | default concurrent Harbor trials used when an operator does not override `n_concurrent` |
+
+Prefer explicit recipe keys for reproducible experiments. Environment values
+are useful for launch profiles and diagnostics, but `operators.rollout` and
+`operators.validate` may set their own concurrency and timeout multipliers.
+Keep the two GEPA stages symmetric when changing execution headroom.
+
 ## Proxy variables
 
 Standard proxy variables are optional and inherited from the host:
@@ -210,4 +229,3 @@ or evaluator failures:
 ```bash
 ./evolve doctor . --profile experiment --probe-model
 ```
-

--- a/docs/reference/operators/rollout.md
+++ b/docs/reference/operators/rollout.md
@@ -32,6 +32,7 @@ operators:
     task_sampling: generation_shuffle
     n_concurrent: 4
     agent_setup_timeout_multiplier: 1
+    verifier_timeout_multiplier: 1
     max_retries: 1
     timeout_s: 3600
 ```
@@ -42,6 +43,10 @@ Important keys:
 - `task_sampling`: `head` or deterministic `generation_shuffle`;
 - `task_names`: optional exact names from the frozen train split;
 - `n_concurrent`: concurrent Harbor trials;
+- `agent_setup_timeout_multiplier`, `agent_timeout_multiplier`, and
+  `verifier_timeout_multiplier`: multiply the corresponding limits declared
+  by each task's `task.toml`; keep the operator `timeout_s` large enough for
+  the resulting longest trial;
 - `agent_env` and agent/runtime settings: inputs forwarded to the rollout
   adapter;
 - `max_retries` and `timeout_s`: infrastructure retry and operator limits.
@@ -62,4 +67,3 @@ runs/harbor-rollouts/gen-N/
 `cases.json` is the method-neutral input to `trace_analyzer`. It includes task
 identity, ordered model/tool events, verifier evidence, outcome, exception,
 usage, timing, and artifact inventory.
-

--- a/docs/reference/operators/validate.md
+++ b/docs/reference/operators/validate.md
@@ -27,6 +27,7 @@ operators:
     variant: minibatch_improvement
     criterion: strict
     n_concurrent: 4
+    verifier_timeout_multiplier: 1
     max_retries: 1
     timeout_s: 3600
 ```
@@ -40,6 +41,14 @@ runs/gen-N/validate/parent-cases.json
 runs/gen-N/validate/child-cases.json
 runs/gen-N/validate/child-eval/
 ```
+
+The child replay accepts the same Harbor reliability controls as `rollout`,
+including `n_concurrent`, timeout multipliers, and `max_retries`. If otherwise
+healthy verifier jobs regularly reach their task-declared timeout, increase
+`verifier_timeout_multiplier` on both `rollout` and `validate`; lowering
+`n_concurrent` can also reduce host contention. These controls change execution
+headroom, not the minibatch comparison criterion. The parent and child settings
+should remain symmetric.
 
 Use the criterion declared by the method, such as `strict` or
 `non_decreasing`; changing it changes the experiment policy.
@@ -55,4 +64,3 @@ runs/gen-N/validate/
 
 If no `validate` block is present, the driver proceeds from mutation (and any
 configured `novelty`) to canonical evaluation.
-

--- a/library/meta_agent/runners/harbor.py
+++ b/library/meta_agent/runners/harbor.py
@@ -335,11 +335,11 @@ def _contains_private_task_name(
     return pattern.search(tail) is not None
 
 
-def _assert_private_tasks_absent(workspace: Path, prompt: str, private_names: tuple[str, ...]) -> None:
+def _private_task_pattern(private_names: tuple[str, ...]) -> re.Pattern[bytes] | None:
     if not private_names:
-        return
+        return None
     encoded_names = tuple(name.encode() for name in private_names)
-    pattern = re.compile(
+    return re.compile(
         rb"(?<!["
         + _TASK_IDENTIFIER_CHARACTERS
         + rb"])(?:"
@@ -348,9 +348,42 @@ def _assert_private_tasks_absent(workspace: Path, prompt: str, private_names: tu
         + _TASK_IDENTIFIER_CHARACTERS
         + rb"])"
     )
+
+
+def _redact_private_tasks_from_run_inputs(workspace: Path, private_names: tuple[str, ...]) -> None:
+    """Remove private split identifiers accidentally echoed by train trajectories.
+
+    Target agents can inspect resources outside the task checkout and may echo a
+    gate or sealed task name into their command output. The rollout remains
+    valid train evidence, but that incidental identifier must not be forwarded
+    to the meta-agent. Only the disposable copied ``runs`` evidence is rewritten;
+    candidate and durable artifact inputs remain protected by the strict check
+    below.
+    """
+
+    pattern = _private_task_pattern(private_names)
+    runs = workspace / "runs"
+    if pattern is None or not runs.is_dir():
+        return
+    for path in runs.rglob("*"):
+        if not path.is_file() or path.is_symlink():
+            continue
+        try:
+            content = path.read_bytes()
+        except OSError:
+            continue
+        redacted = pattern.sub(b"[PRIVATE_TASK]", content)
+        if redacted != content:
+            path.write_bytes(redacted)
+
+
+def _assert_private_tasks_absent(workspace: Path, prompt: str, private_names: tuple[str, ...]) -> None:
+    pattern = _private_task_pattern(private_names)
+    if pattern is None:
+        return
     if pattern.search(prompt.encode()):
         raise RuntimeError("Harbor meta-agent prompt contains a private gate/sealed task identifier")
-    overlap = max(len(name) for name in encoded_names) + 1
+    overlap = max(len(name.encode()) for name in private_names) + 1
     for path in workspace.rglob("*"):
         if not path.is_file() or ".git" in path.relative_to(workspace).parts:
             continue
@@ -427,7 +460,9 @@ def _prepare_bundle(
             _copy_visible_run_inputs(ctx, workspace)
         _copy_artifact_inputs(ctx, workspace)
         if not _expose_gate_data(ctx.config):
-            _assert_private_tasks_absent(workspace, prompt, _private_task_names(ctx.workspace))
+            private_names = _private_task_names(ctx.workspace)
+            _redact_private_tasks_from_run_inputs(workspace, private_names)
+            _assert_private_tasks_absent(workspace, prompt, private_names)
             _initialize_sanitized_git(workspace)
         return _WorkspaceBundle(staging, task_root, workspace, roots, _tree_manifest(workspace))
     except Exception:

--- a/library/rollout/harbor.py
+++ b/library/rollout/harbor.py
@@ -927,6 +927,10 @@ class HarborRollout(RolloutOperator):
             ctx.config.get("agent_timeout_multiplier"),
             _float_value(eval_env.get("EVOLVE_HARBOR_AGENT_TIMEOUT_MULTIPLIER"), 1),
         )
+        verifier_timeout_multiplier = _float_value(
+            ctx.config.get("verifier_timeout_multiplier"),
+            _float_value(eval_env.get("EVOLVE_HARBOR_VERIFIER_TIMEOUT_MULTIPLIER"), 1),
+        )
         max_retries = _configured_max_retries(ctx.config, eval_env)
         field_limit = _positive_int(ctx.config.get("field_limit"), 2000)
         pass_threshold = _float_value(ctx.config.get("pass_threshold"), 1.0)
@@ -949,6 +953,8 @@ class HarborRollout(RolloutOperator):
             str(max(setup_timeout_multiplier, 1)),
             "--agent-timeout-multiplier",
             str(max(agent_timeout_multiplier, 1)),
+            "--verifier-timeout-multiplier",
+            str(max(verifier_timeout_multiplier, 1)),
             "--max-retries",
             str(max_retries),
             "-y",

--- a/scaffolds/evaluators/harbor/harbor_artifacts.py
+++ b/scaffolds/evaluators/harbor/harbor_artifacts.py
@@ -342,7 +342,10 @@ def _reward(result: dict[str, Any]) -> float | None:
 
 
 def _verifier_timeout_is_final_zero(jobs_dir: Path) -> bool:
-    configs = [path for path in jobs_dir.glob("*/config.json") if path.parent.parent == jobs_dir]
+    root_config = jobs_dir / "config.json"
+    configs = [root_config] if root_config.is_file() else []
+    if not configs:
+        configs = [path for path in jobs_dir.glob("*/config.json") if path.parent.parent == jobs_dir]
     if len(configs) != 1:
         return False
     try:

--- a/tests/test_harbor_artifacts.py
+++ b/tests/test_harbor_artifacts.py
@@ -186,6 +186,32 @@ def test_final_retried_verifier_timeout_scores_zero_and_preserves_sibling(tmp_pa
     assert rewards == [0.0, 1.0]
 
 
+def test_final_retried_verifier_timeout_uses_root_job_config_with_trial_configs(tmp_path: Path) -> None:
+    jobs = tmp_path / "jobs"
+    jobs.mkdir()
+    (jobs / "config.json").write_text(
+        json.dumps({"retry": {"max_retries": 1, "exclude_exceptions": ["AgentTimeoutError"]}})
+    )
+    for task in ("case-a", "case-b"):
+        trial = jobs / f"{task}__one"
+        write_trial(
+            trial,
+            task=task,
+            trial="one",
+            reward=None if task == "case-a" else 1.0,
+            exception_type="VerifierTimeoutError" if task == "case-a" else None,
+        )
+        (trial / "config.json").write_text(json.dumps({"trial_name": f"{task}__one"}))
+
+    vector, _artifacts, rewards = collect_harbor_artifacts(jobs)
+
+    timeout = vector["tasks"]["case-a"]["trials"][0]
+    assert timeout["status"] == "timeout"
+    assert timeout["reward"] == 0.0
+    assert timeout["owner"] == "benchmark_verifier"
+    assert rewards == [0.0, 1.0]
+
+
 def test_verifier_timeout_without_retry_or_agent_result_remains_infrastructure(tmp_path: Path) -> None:
     jobs = tmp_path / "jobs"
     write_job_config(jobs, max_retries=0)

--- a/tests/test_harbor_meta_agent.py
+++ b/tests/test_harbor_meta_agent.py
@@ -1274,17 +1274,13 @@ def test_harbor_bundle_never_exposes_gate_or_sealed_data(tmp_path: Path, traject
         shutil.rmtree(bundle.staging, ignore_errors=True)
 
 
-@pytest.mark.parametrize("leak_source", ["prompt", "train-evidence"])
-def test_harbor_bundle_rejects_private_task_identifiers(tmp_path: Path, leak_source: str) -> None:
+def test_harbor_bundle_rejects_private_task_identifiers_in_prompt(tmp_path: Path) -> None:
     checkout, run_dir = _checkout(tmp_path)
     evaluator = checkout / "evaluator"
     evaluator.mkdir()
     (evaluator / "splits.json").write_text(
         json.dumps({"tasks": {"train": ["train-task"], "gate": ["gate-secret-task"], "sealed": []}})
     )
-    prompt = "analyze gate-secret-task" if leak_source == "prompt" else "safe train evidence"
-    if leak_source == "train-evidence":
-        (run_dir / "trace_analyzer" / "evidence" / "raw_traces.jsonl").write_text('{"task_name":"gate-secret-task"}\n')
     runner = _harbor_runner_module()
     surface = runner.load_surface_policy(checkout)
 
@@ -1294,8 +1290,39 @@ def test_harbor_bundle_rejects_private_task_identifiers(tmp_path: Path, leak_sou
             _ctx(checkout, run_dir),
             ["target"],
             surface,
-            prompt=prompt,
+            prompt="analyze gate-secret-task",
         )
+
+
+def test_harbor_bundle_redacts_private_task_identifiers_echoed_by_train_rollout(
+    tmp_path: Path,
+) -> None:
+    checkout, run_dir = _checkout(tmp_path)
+    evaluator = checkout / "evaluator"
+    evaluator.mkdir()
+    (evaluator / "splits.json").write_text(
+        json.dumps({"tasks": {"train": ["train-task"], "gate": ["gate-secret-task"], "sealed": []}})
+    )
+    rollout = run_dir / "rollout"
+    rollout.mkdir(exist_ok=True)
+    (rollout / "cases.json").write_text(
+        '{"task_name":"train-task","observation":"found gate-secret-task in an external listing"}\n'
+    )
+    runner = _harbor_runner_module()
+    surface = runner.load_surface_policy(checkout)
+    bundle = runner._prepare_bundle(
+        checkout,
+        _ctx(checkout, run_dir),
+        ["target"],
+        surface,
+        prompt="safe train evidence",
+    )
+    try:
+        copied = (bundle.workspace / "runs" / "gen-1" / "rollout" / "cases.json").read_text()
+        assert "gate-secret-task" not in copied
+        assert "[PRIVATE_TASK]" in copied
+    finally:
+        shutil.rmtree(bundle.staging, ignore_errors=True)
 
 
 def test_harbor_bundle_omits_trajectory_judge_workdirs(tmp_path: Path) -> None:

--- a/tests/test_m8_dataset_splits.py
+++ b/tests/test_m8_dataset_splits.py
@@ -366,6 +366,7 @@ def test_harbor_rollout_uses_only_frozen_train_task_names(tmp_path: Path, monkey
             "jobs_dir": str(tmp_path / "jobs"),
             "environment": "custom.local:Environment",
             "environment_kwargs": {"workdir": "/workspace"},
+            "verifier_timeout_multiplier": 2,
         },
         rng=random.Random(0),
     )
@@ -398,6 +399,7 @@ def test_harbor_rollout_uses_only_frozen_train_task_names(tmp_path: Path, monkey
     assert ("--model", "openai/test-model") in zip(captured, captured[1:], strict=False)
     assert captured[captured.index("--env") + 1] == "custom.local:Environment"
     assert captured[captured.index("--environment-kwarg") + 1] == 'workdir="/workspace"'
+    assert captured[captured.index("--verifier-timeout-multiplier") + 1] == "2.0"
     assert result.summary["split"] == "train"
 
 


### PR DESCRIPTION
## Summary

- redact gate/sealed task identifiers that are accidentally echoed into copied train rollout evidence before it reaches the meta-agent
- read Harbor retry policy from the root job config when classifying final verifier timeouts
- add configurable verifier-timeout headroom to Harbor rollout and validation, including environment-variable and operator documentation

## Validation

- `pytest -q tests/test_harbor_meta_agent.py tests/test_harbor_artifacts.py tests/test_m8_dataset_splits.py` — 94 passed
- full `pytest -q` suite passed
- `ruff check .` passed
- `ruff format --check .` passed
- `ty check --python <locked-env>/bin/python` passed
- `git diff --check` passed
