### PR TITLE
docs: add resilient repository statistics

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,6 +7,7 @@ on:
       - "docs/**"
       - "mkdocs.yml"
       - "pyproject.toml"
+      - "scripts/fetch_repository_stats.py"
       - "uv.lock"
       - ".github/workflows/docs.yml"
   pull_request:
@@ -14,8 +15,11 @@ on:
       - "docs/**"
       - "mkdocs.yml"
       - "pyproject.toml"
+      - "scripts/fetch_repository_stats.py"
       - "uv.lock"
       - ".github/workflows/docs.yml"
+  schedule:
+    - cron: "17 0,12 * * *"
   workflow_dispatch:
 
 permissions:
@@ -39,6 +43,11 @@ jobs:
         with:
           enable-cache: true
           python-version: "3.12"
+
+      - name: Refresh repository statistics
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: python scripts/fetch_repository_stats.py
 
       - name: Check lockfile
         run: uv lock --check

--- a/docs/assets/repository-stats.json
+++ b/docs/assets/repository-stats.json
@@ -1,0 +1,7 @@
+{
+  "fetched_at": "2026-08-10T07:06:41.657569Z",
+  "forks": 0,
+  "repository": "simple-agent-lab/EvolveX",
+  "schema_version": 1,
+  "stars": 19
+}

--- a/docs/javascripts/repository-stats.js
+++ b/docs/javascripts/repository-stats.js
@@ -1,0 +1,134 @@
+(() => {
+  const selector = "[data-evolvex-repository-stats]"
+  const cacheLifetimeMs = 10 * 60 * 1000
+  let currentStats
+  let pendingStats
+
+  function normalize(payload) {
+    const stars = Number(payload.stars ?? payload.stargazers_count)
+    const forks = Number(payload.forks ?? payload.forks_count)
+    if (!Number.isSafeInteger(stars) || stars < 0 || !Number.isSafeInteger(forks) || forks < 0) {
+      throw new Error("Invalid repository statistics")
+    }
+    return { stars, forks }
+  }
+
+  function formatCount(value) {
+    if (value < 1000) return String(value)
+    const units = [
+      [1_000_000_000, "b"],
+      [1_000_000, "m"],
+      [1_000, "k"],
+    ]
+    const [divisor, suffix] = units.find(([threshold]) => value >= threshold)
+    const scaled = value / divisor
+    return `${scaled >= 10 ? scaled.toFixed(0) : scaled.toFixed(1).replace(/\.0$/, "")}${suffix}`
+  }
+
+  function repositoryApiUrl(source) {
+    const repository = new URL(source.href)
+    const [owner, name] = repository.pathname.split("/").filter(Boolean)
+    if (repository.hostname !== "github.com" || !owner || !name) {
+      throw new Error("Unsupported repository URL")
+    }
+    return `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}`
+  }
+
+  function cacheKey(source) {
+    return `evolvex-repository-stats:v1:${source.href}`
+  }
+
+  function readCache(source) {
+    try {
+      const cached = JSON.parse(sessionStorage.getItem(cacheKey(source)))
+      if (Date.now() - cached.stored_at > cacheLifetimeMs) return undefined
+      return normalize(cached)
+    } catch {
+      return undefined
+    }
+  }
+
+  function writeCache(source, stats) {
+    try {
+      sessionStorage.setItem(cacheKey(source), JSON.stringify({ ...stats, stored_at: Date.now() }))
+    } catch {
+      // Storage can be disabled without affecting either network fallback.
+    }
+  }
+
+  async function fetchLiveStats(source) {
+    const controller = new AbortController()
+    const timeout = window.setTimeout(() => controller.abort(), 4000)
+    try {
+      const response = await fetch(repositoryApiUrl(source), {
+        cache: "no-store",
+        headers: { Accept: "application/vnd.github+json" },
+        signal: controller.signal,
+      })
+      if (!response.ok) throw new Error(`GitHub API returned ${response.status}`)
+      return normalize(await response.json())
+    } finally {
+      window.clearTimeout(timeout)
+    }
+  }
+
+  async function fetchFallbackStats(source) {
+    const response = await fetch(source.dataset.evolvexRepositoryStats, { cache: "no-cache" })
+    if (!response.ok) throw new Error(`Repository statistics fallback returned ${response.status}`)
+    return normalize(await response.json())
+  }
+
+  async function loadStats(source) {
+    const cached = readCache(source)
+    if (cached) return cached
+    let stats
+    try {
+      stats = await fetchLiveStats(source)
+    } catch {
+      stats = await fetchFallbackStats(source)
+    }
+    writeCache(source, stats)
+    return stats
+  }
+
+  function renderFact(kind, value) {
+    const fact = document.createElement("li")
+    fact.className = `md-source__fact md-source__fact--${kind}`
+    fact.textContent = formatCount(value)
+    return fact
+  }
+
+  function render(stats) {
+    for (const source of document.querySelectorAll(selector)) {
+      const repository = source.querySelector(":scope > .md-source__repository")
+      if (!repository) continue
+      let facts = repository.querySelector(":scope > .md-source__facts")
+      if (!facts) {
+        facts = document.createElement("ul")
+        facts.className = "md-source__facts"
+        repository.append(facts)
+      }
+      repository.classList.add("md-source__repository--active")
+      facts.replaceChildren(renderFact("stars", stats.stars), renderFact("forks", stats.forks))
+    }
+  }
+
+  function hydrate() {
+    const source = document.querySelector(selector)
+    if (!source) return
+    if (currentStats) {
+      render(currentStats)
+      return
+    }
+    pendingStats ??= loadStats(source)
+    pendingStats.then((stats) => {
+      currentStats = stats
+      render(stats)
+    }).catch(() => {
+      // Keep the repository link usable when both the live API and fallback fail.
+    })
+  }
+
+  hydrate()
+  if (typeof document$ !== "undefined") document$.subscribe(hydrate)
+})()

--- a/docs/overrides/partials/source.html
+++ b/docs/overrides/partials/source.html
@@ -1,0 +1,15 @@
+{# Use EvolveX's live-API-first, same-origin-fallback repository statistics. #}
+<a
+  href="{{ config.repo_url }}"
+  title="{{ lang.t('source') }}"
+  class="md-source"
+  data-evolvex-repository-stats="{{ 'assets/repository-stats.json' | url }}"
+>
+  <div class="md-source__icon md-icon">
+    {% set icon = config.theme.icon.repo or "fontawesome/brands/git-alt" %}
+    {% include ".icons/" ~ icon ~ ".svg" %}
+  </div>
+  <div class="md-source__repository">
+    {{ config.repo_name }}
+  </div>
+</a>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,7 @@ edit_uri: edit/main/docs/
 
 theme:
   name: material
+  custom_dir: docs/overrides
   logo: evolve-mark.svg
   favicon: evolve-mark.svg
   language: en
@@ -79,6 +80,9 @@ markdown_extensions:
 
 plugins:
   - search
+
+extra_javascript:
+  - javascripts/repository-stats.js
 
 exclude_docs: |
   designs/

--- a/scripts/fetch_repository_stats.py
+++ b/scripts/fetch_repository_stats.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Fetch authenticated GitHub repository statistics for the documentation build."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+DEFAULT_REPOSITORY = "simple-agent-lab/EvolveX"
+DEFAULT_OUTPUT = Path("docs/assets/repository-stats.json")
+
+
+def _count(payload: dict[str, Any], key: str) -> int:
+    value = payload.get(key)
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise ValueError(f"GitHub response has invalid {key}")
+    return value
+
+
+def fetch_repository_stats(repository: str, token: str | None) -> dict[str, Any]:
+    request = urllib.request.Request(
+        f"https://api.github.com/repos/{repository}",
+        headers={
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "EvolveX-docs-build",
+            "X-GitHub-Api-Version": "2022-11-28",
+            **({"Authorization": f"Bearer {token}"} if token else {}),
+        },
+    )
+    with urllib.request.urlopen(request, timeout=20) as response:
+        payload = json.load(response)
+    if not isinstance(payload, dict):
+        raise ValueError("GitHub response is not an object")
+    return {
+        "schema_version": 1,
+        "repository": repository,
+        "stars": _count(payload, "stargazers_count"),
+        "forks": _count(payload, "forks_count"),
+        "fetched_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+    }
+
+
+def write_repository_stats(output: Path, stats: dict[str, Any]) -> None:
+    output.parent.mkdir(parents=True, exist_ok=True)
+    temporary = output.with_suffix(f"{output.suffix}.tmp")
+    temporary.write_text(json.dumps(stats, indent=2, sort_keys=True) + "\n")
+    temporary.replace(output)
+
+
+def has_usable_fallback(output: Path) -> bool:
+    try:
+        payload = json.loads(output.read_text())
+        return (
+            isinstance(payload, dict)
+            and payload.get("schema_version") == 1
+            and isinstance(payload.get("repository"), str)
+            and _count(payload, "stars") >= 0
+            and _count(payload, "forks") >= 0
+        )
+    except (OSError, ValueError, json.JSONDecodeError):
+        return False
+
+
+def main() -> int:
+    repository = os.environ.get("GITHUB_REPOSITORY", DEFAULT_REPOSITORY)
+    output = Path(os.environ.get("EVOLVEX_REPOSITORY_STATS_PATH", DEFAULT_OUTPUT))
+    try:
+        stats = fetch_repository_stats(repository, os.environ.get("GITHUB_TOKEN"))
+        write_repository_stats(output, stats)
+    except (OSError, ValueError, json.JSONDecodeError, urllib.error.URLError) as exc:
+        if has_usable_fallback(output):
+            print(f"warning: keeping existing repository statistics after refresh failed: {exc}", file=sys.stderr)
+            return 0
+        else:
+            print(f"failed to refresh repository statistics: {exc}", file=sys.stderr)
+            return 1
+    print(f"wrote repository statistics to {output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_docs_repository_stats.py
+++ b/tests/test_docs_repository_stats.py
@@ -1,0 +1,71 @@
+import importlib.util
+import json
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _fetch_module():
+    path = ROOT / "scripts" / "fetch_repository_stats.py"
+    spec = importlib.util.spec_from_file_location("fetch_repository_stats", path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_repository_stats_fallback_files_are_wired_into_mkdocs() -> None:
+    config = yaml.safe_load((ROOT / "mkdocs.yml").read_text())
+    assert config["theme"]["custom_dir"] == "docs/overrides"
+    assert "javascripts/repository-stats.js" in config["extra_javascript"]
+
+    source = (ROOT / "docs" / "overrides" / "partials" / "source.html").read_text()
+    assert "data-evolvex-repository-stats" in source
+    assert 'data-md-component="source"' not in source
+
+    javascript = (ROOT / "docs" / "javascripts" / "repository-stats.js").read_text()
+    assert "https://api.github.com/repos/" in javascript
+    assert "evolvexRepositoryStats" in javascript
+    assert "md-source__fact--${kind}" in javascript
+
+
+def test_docs_workflow_refreshes_repository_stats_twice_daily() -> None:
+    workflow = yaml.safe_load((ROOT / ".github" / "workflows" / "docs.yml").read_text())
+    triggers = workflow[True]
+    assert triggers["schedule"] == [{"cron": "17 0,12 * * *"}]
+    assert "scripts/fetch_repository_stats.py" in triggers["push"]["paths"]
+    assert "scripts/fetch_repository_stats.py" in triggers["pull_request"]["paths"]
+
+    steps = workflow["jobs"]["build"]["steps"]
+    refresh = next(step for step in steps if step.get("name") == "Refresh repository statistics")
+    assert refresh["run"] == "python scripts/fetch_repository_stats.py"
+    assert refresh["env"]["GITHUB_TOKEN"] == "${{ github.token }}"
+    assert steps.index(refresh) < next(
+        index for index, step in enumerate(steps) if step.get("name") == "Build documentation"
+    )
+
+
+def test_repository_stats_json_has_valid_counts() -> None:
+    payload = json.loads((ROOT / "docs" / "assets" / "repository-stats.json").read_text())
+    assert payload["schema_version"] == 1
+    assert payload["repository"] == "simple-agent-lab/EvolveX"
+    assert isinstance(payload["stars"], int) and payload["stars"] >= 0
+    assert isinstance(payload["forks"], int) and payload["forks"] >= 0
+
+
+def test_repository_stats_writer_is_atomic(tmp_path: Path) -> None:
+    module = _fetch_module()
+    output = tmp_path / "nested" / "repository-stats.json"
+    stats = {
+        "schema_version": 1,
+        "repository": "example/project",
+        "stars": 12,
+        "forks": 3,
+        "fetched_at": "2026-08-10T00:00:00Z",
+    }
+    module.write_repository_stats(output, stats)
+    assert json.loads(output.read_text()) == stats
+    assert not output.with_suffix(".json.tmp").exists()
+    assert module.has_usable_fallback(output)


### PR DESCRIPTION
## Summary

- fetch live GitHub star and fork counts in the browser, with a same-origin JSON fallback for rate limits and network failures
- refresh the fallback statistics through the authenticated documentation workflow every 12 hours
- preserve the Material for MkDocs repository-facts presentation while avoiding its competing unauthenticated request
- retain the last valid JSON when a scheduled refresh cannot reach GitHub

## Validation

- `pytest -q tests/test_docs_repository_stats.py tests/test_public_repository.py` — 15 passed
- `mkdocs build --strict` passed
- `ruff check .` passed
- `ruff format --check .` passed
- `ty check --python .venv/bin/python` passed
- `node --check docs/javascripts/repository-stats.js` passed
- verified the unauthenticated 403 rate-limit path keeps and serves the JSON fallback

## Full-suite note

The full test suite has two unrelated `candidate uv lock validation failed` failures for the AHE and HyperAgents runtime-conformance cases. Both failures reproduce unchanged on `origin/main`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Documentation now displays repository star and fork counts.
  - Statistics can refresh from live repository data and remain available through cached or fallback values when updates fail.
  - Repository links include the configured name, URL, and icon.

- **Documentation**
  - Repository statistics are refreshed automatically twice daily.
  - Documentation navigation updates statistics smoothly without requiring a full page reload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->