### PR TITLE
feat(harbor): add Prime Agent adapter with continual-harness support

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -78,7 +78,7 @@ decision (and usually a demolition pass) instead of silent sprawl.
 | `integrations/harbor/_agent_roles.py` | 50 | canonical MiniSWE role names and narrow compatibility aliases |
 | `integrations/harbor/_candidate_source.py` | 75 | exact candidate-source validation and archive-copy boundary |
 | `integrations/harbor/codex_candidate.py` | 75 | Codex adapter for OpenAI-compatible Responses endpoints |
-| `integrations/harbor/prime_agent.py` | 260 | Prime Agent adapter with continual-harness injection and export |
+| `integrations/harbor/prime_agent.py` | 275 | Prime Agent adapter with continual-harness injection and export |
 | `integrations/harbor/miniswe_candidate.py` | 550 | exact-candidate MiniSWE Harbor evaluator agent |
 | `integrations/harbor/miniswe_task_file.py` | 130 | large-task MiniSWE meta-agent transport |
 | `meta_agent_budget.py` | 150 | shared Harbor meta-agent retry and timeout budget calculations |
@@ -96,7 +96,7 @@ each workspace, immutable there because it sits outside the mutable surface
 | `frozen/interfaces.py` | 350 | operator ABCs, registry, result schemas, and strict operator payload validation |
 | `frozen/sdk.py` | 300 | Python operator entrypoint and file-contract IO; no library algorithm policy |
 
-Total `src/evolve/` budget: **16990 lines**. The budget admits the explicit content-backed
+Total `src/evolve/` budget: **17005 lines**. The budget admits the explicit content-backed
 evaluation-contract boundaries, the opt-in in-place Harbor runtime, and the redacted trace-analysis
 boundary between rollout and feedback assembly; if the mechanism wants to
 grow past that, something belongs in a workspace operator instead —

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -78,6 +78,7 @@ decision (and usually a demolition pass) instead of silent sprawl.
 | `integrations/harbor/_agent_roles.py` | 50 | canonical MiniSWE role names and narrow compatibility aliases |
 | `integrations/harbor/_candidate_source.py` | 75 | exact candidate-source validation and archive-copy boundary |
 | `integrations/harbor/codex_candidate.py` | 75 | Codex adapter for OpenAI-compatible Responses endpoints |
+| `integrations/harbor/prime_agent.py` | 260 | Prime Agent adapter with continual-harness injection and export |
 | `integrations/harbor/miniswe_candidate.py` | 550 | exact-candidate MiniSWE Harbor evaluator agent |
 | `integrations/harbor/miniswe_task_file.py` | 130 | large-task MiniSWE meta-agent transport |
 | `meta_agent_budget.py` | 150 | shared Harbor meta-agent retry and timeout budget calculations |
@@ -95,7 +96,7 @@ each workspace, immutable there because it sits outside the mutable surface
 | `frozen/interfaces.py` | 350 | operator ABCs, registry, result schemas, and strict operator payload validation |
 | `frozen/sdk.py` | 300 | Python operator entrypoint and file-contract IO; no library algorithm policy |
 
-Total `src/evolve/` budget: **16730 lines**. The budget admits the explicit content-backed
+Total `src/evolve/` budget: **16990 lines**. The budget admits the explicit content-backed
 evaluation-contract boundaries, the opt-in in-place Harbor runtime, and the redacted trace-analysis
 boundary between rollout and feedback assembly; if the mechanism wants to
 grow past that, something belongs in a workspace operator instead —

--- a/docs/guides/prime-agent.md
+++ b/docs/guides/prime-agent.md
@@ -21,7 +21,9 @@ harbor run \
 `auth_json_path` points at the credential store Prime writes on the host
 (`~/.prime/agent/auth.json` after `prime-agent` `/login`); the adapter uploads
 it into the isolated agent directory it creates per trial. Credentials never
-need to be baked into an image.
+need to be baked into an image, and the adapter deletes `auth.json` from that
+directory before exporting it — the export is a retained Harbor artifact, so a
+token left in it would outlive the trial and travel with the results.
 
 In a recipe:
 

--- a/docs/guides/prime-agent.md
+++ b/docs/guides/prime-agent.md
@@ -1,0 +1,110 @@
+# Prime Agent
+
+[Prime Agent](https://github.com/PrimeIntellect-ai/prime-agent) is a coding
+agent built around a **continual harness**: supplemental prompts, memories,
+skills and subagent specs that the agent refines itself while it works. The
+adapter at `evolve.integrations.harbor.prime_agent:PrimeAgent` runs it against
+Harbor tasks and, optionally, pins each run to a specific harness checkpoint so
+a chain of harness generations can be measured.
+
+## Running a task
+
+```bash
+harbor run \
+  -p /path/to/tasks \
+  --agent evolve.integrations.harbor.prime_agent:PrimeAgent \
+  --model openai-codex/gpt-5.6-sol \
+  --agent-kwarg auth_json_path='"/home/you/.prime/agent/auth.json"' \
+  --agent-kwarg thinking=medium
+```
+
+`auth_json_path` points at the credential store Prime writes on the host
+(`~/.prime/agent/auth.json` after `prime-agent` `/login`); the adapter uploads
+it into the isolated agent directory it creates per trial. Credentials never
+need to be baked into an image.
+
+In a recipe:
+
+```yaml
+evaluator:
+  engine: harbor
+  agent: evolve.integrations.harbor.prime_agent:PrimeAgent
+```
+
+## Measuring the continual harness
+
+The adapter isolates Prime's state under `--agent-kwarg agent_dir` (default
+`/tmp/prime-agent-dir`), injects a checkpoint before the run and exports the
+whole directory afterwards to `<logs>/prime-agent-dir/`:
+
+```bash
+  --agent-kwarg auto_refine=true \
+  --agent-kwarg harness_state_path='"checkpoints/gen-003/harness_state.json"'
+```
+
+Harbor tears every trial container down, so harness state does not survive from
+one task to the next on its own — a learning stream has to export after each
+episode and inject the result into the next.
+
+Two upstream behaviours are worth knowing before interpreting a result.
+
+**Refinement requires a session.** Prime gates auto-refine on a session-local
+harness directory, so a run started with `--no-session` never refines, whatever
+`autoRefine` says. The adapter therefore keeps a session when `auto_refine=true`
+and stays sessionless otherwise, so a frozen or probe run cannot persist
+anything. This matters because a sessionless run still looks completely
+healthy — reward, trajectory and exit status are all normal — while producing no
+refinement at all.
+
+**The shipped trigger thresholds rarely fire on a benchmark.** Prime defaults to
+`turnInterval=25` and a 20 minute cooldown; a task that finishes in a handful of
+turns never reaches either. Leave them alone to measure shipped behaviour, or
+set them explicitly to measure refinement itself:
+
+```bash
+  --agent-kwarg refine_turn_interval=1 \
+  --agent-kwarg refine_cooldown_ms=0
+```
+
+These are different questions with different answers, so the choice belongs in
+the experiment configuration rather than in a default.
+
+Refinement also writes to the **session-local** harness rather than the global
+one, so an export contains both the injected parent copy and whatever the
+episode produced. Carrying a chain forward means merging them, not picking one:
+preferring the global file replays the parent unchanged, and preferring the
+session-local file discards everything learned earlier.
+
+## Restricted networks: a pre-baked runtime
+
+By default the adapter installs Node and Prime Agent inside the task container.
+Prime's postinstall provisions a Python runtime, which needs unrestricted access
+to several release CDNs; where that is unavailable, build the runtime once and
+mount it read-only instead:
+
+```bash
+docker run --rm -v "$PWD/out:/out" debian:bookworm bash -euxc '
+  apt-get update && apt-get install -y curl ca-certificates xz-utils
+  export UV_PYTHON_INSTALL_DIR=/opt/prime-runtime/python
+  export PRIME_AGENT_KERNEL_VENV=/opt/prime-runtime/kernel-venv
+  # …install Node and prime-agent under /opt/prime-runtime…
+  tar -C /opt -czf /out/prime-runtime.tar.gz prime-runtime'
+```
+
+Build the interpreter and the kernel venv at the paths they will occupy at run
+time: a virtualenv bakes absolute paths into `pyvenv.cfg` and its script
+shebangs, so one built elsewhere and copied in will not start.
+
+Then mount it and point the adapter at it:
+
+```bash
+harbor run \
+  --mounts '[{"type":"bind","source":"/srv/prime-runtime","target":"/opt/prime-runtime","read_only":true}]' \
+  --agent-kwarg runtime_prefix='"/opt/prime-runtime"' \
+  ...
+```
+
+`install()` degrades to a version check and the run needs no network for the
+agent itself. Pinning the bundle's digest also fixes Node, Prime Agent and the
+Python runtime together, which is a stronger guarantee than a version string
+when arms of an experiment run on different days.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,6 +45,7 @@ nav:
       - Running Evolve reliably: guides/operations.md
       - Meta-agent execution: guides/meta-agents.md
       - Local Harbor environment: guides/local-environment.md
+      - Prime Agent: guides/prime-agent.md
   - Reference:
       - Environment Variables: reference/environment-variables.md
       - Operator overview: reference/operators.md

--- a/src/evolve/integrations/harbor/prime_agent.py
+++ b/src/evolve/integrations/harbor/prime_agent.py
@@ -1,0 +1,250 @@
+"""Prime Agent Harbor adapter, including its continual-harness state.
+
+Prime Agent descends from ``badlogic/pi-mono`` and kept that CLI contract, so
+the invocation and usage accounting mirror Harbor's ``pi`` adapter. What is
+specific to Prime is the continual harness: supplemental prompts, memories,
+skills and subagent specs that Prime refines itself during a run. This adapter
+can pin a run to a given harness checkpoint and export whatever the run left
+behind, which is what makes a chain of harness generations observable.
+
+Two upstream behaviours are easy to trip over and are handled here explicitly:
+
+* ``--no-session`` disables refinement *structurally*. Prime gates auto-refine
+  on a session-local harness directory, so a sessionless run never refines no
+  matter how ``autoRefine`` is configured. Sessions are therefore kept whenever
+  refinement is expected, and only frozen runs stay sessionless.
+* Prime ships ``turnInterval=25`` and a 20 minute cooldown, which never fire on
+  a short benchmark episode. ``refine_turn_interval`` / ``refine_cooldown_ms``
+  make that threshold an explicit experiment parameter rather than an
+  assumption.
+"""
+
+from __future__ import annotations
+
+import json
+import shlex
+from pathlib import Path
+from typing import Any
+
+from harbor.agents.installed.base import BaseInstalledAgent, CliFlag, with_prompt_template
+from harbor.agents.installed.node_install import nvm_node_install_snippet
+from harbor.models.agent.context import AgentContext
+
+INSTALL_URL = "https://app.primeintellect.ai/prime-agent/install.sh"
+AGENT_DIR = "/tmp/prime-agent-dir"
+KERNEL_VENV_DIR = "/tmp/prime-kernel-venv"
+OUTPUT_FILENAME = "prime-agent.jsonl"
+EXPORT_DIRNAME = "prime-agent-dir"
+THINKING_LEVELS = ("off", "minimal", "low", "medium", "high", "xhigh", "max")
+PROXY_ENV_NAMES = ("HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "http_proxy", "https_proxy", "no_proxy")
+
+
+class PrimeRuntimeMissingError(RuntimeError):
+    pass
+
+
+class PrimeAgent(BaseInstalledAgent):
+    """Run Prime Agent against a Harbor task, optionally pinned to a harness."""
+
+    CLI_FLAGS = [
+        CliFlag("thinking", cli="--thinking", type="enum", choices=list(THINKING_LEVELS)),
+    ]
+
+    def __init__(
+        self,
+        *args: Any,
+        auth_json_path: str | Path | None = None,
+        harness_state_path: str | Path | None = None,
+        agent_dir: str = AGENT_DIR,
+        auto_refine: bool = False,
+        refine_turn_interval: int | None = None,
+        refine_cooldown_ms: int | None = None,
+        runtime_prefix: str | None = None,
+        kernel_venv_dir: str = KERNEL_VENV_DIR,
+        install_url: str = INSTALL_URL,
+        export_agent_dir: bool = True,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self._auth_json_path = Path(auth_json_path) if auth_json_path else None
+        self._harness_state_path = Path(harness_state_path) if harness_state_path else None
+        self._agent_dir = agent_dir
+        self._auto_refine = auto_refine
+        self._refine_turn_interval = refine_turn_interval
+        self._refine_cooldown_ms = refine_cooldown_ms
+        # Set to a mount point to skip the network install entirely; see
+        # docs/guides/prime-agent.md for building the runtime bundle.
+        self._runtime_prefix = runtime_prefix
+        self._kernel_venv_dir = kernel_venv_dir
+        self._install_url = install_url
+        self._export_agent_dir = export_agent_dir
+
+    @staticmethod
+    def name() -> str:
+        return "prime-agent"
+
+    def get_version_command(self) -> str | None:
+        # prime-agent prints its version on stderr; without the redirect Harbor
+        # records the agent version as "unknown".
+        return f"{self._path_export()} prime-agent --version 2>&1"
+
+    def parse_version(self, stdout: str) -> str:
+        return stdout.strip().splitlines()[-1].strip()
+
+    def _path_export(self) -> str:
+        prefix = f"{self._runtime_prefix}/bin:" if self._runtime_prefix else ""
+        return f'. ~/.nvm/nvm.sh 2>/dev/null; export PATH="{prefix}$HOME/.local/bin:$PATH";'
+
+    def _proxy_env(self) -> dict[str, str]:
+        return {name: value for name in PROXY_ENV_NAMES if (value := self._get_env(name))}
+
+    async def _install_from_runtime(self, environment) -> None:
+        """Verify a pre-baked runtime mount instead of installing over the network."""
+        prefix = shlex.quote(str(self._runtime_prefix))
+        venv = shlex.quote(self._kernel_venv_dir)
+        await self.exec_as_agent(
+            environment,
+            command=(
+                "set -euo pipefail; "
+                f"test -x {prefix}/bin/prime-agent || "
+                f'{{ echo "prime runtime missing at {self._runtime_prefix}" >&2; exit 1; }}; '
+                # Prime bootstraps a lock beside the kernel venv, so it needs a
+                # writable copy even when the runtime itself is mounted read-only.
+                # Absolute paths inside the venv still resolve into the mount.
+                f"if [ -d {prefix}/kernel-venv ] && [ ! -d {venv} ]; then "
+                f"cp -a {prefix}/kernel-venv {venv}; fi; "
+                f"{self._path_export()} prime-agent --version 2>&1"
+            ),
+        )
+
+    async def install(self, environment) -> None:
+        if self._runtime_prefix:
+            await self._install_from_runtime(environment)
+            return
+
+        env = self._proxy_env()
+        await self.exec_as_root(
+            environment,
+            command="apt-get update && apt-get install -y curl ca-certificates",
+            env={"DEBIAN_FRONTEND": "noninteractive", **env},
+        )
+        # The installer runs `npm install -g` on the release tarball, so Node has
+        # to exist first. Keep npm's prefix inside $HOME: agent users in task
+        # images rarely own the system-wide prefix.
+        await self.exec_as_agent(
+            environment,
+            command=(
+                "set -euo pipefail; "
+                f"{nvm_node_install_snippet()} && "
+                'export npm_config_prefix="$HOME/.local" && '
+                'mkdir -p "$HOME/.local/bin" && '
+                f"curl -fsSL {shlex.quote(self._install_url)} -o /tmp/prime-agent-install.sh && "
+                "sh /tmp/prime-agent-install.sh && "
+                'export PATH="$HOME/.local/bin:$PATH" && '
+                "prime-agent --version 2>&1"
+            ),
+            env=env,
+        )
+
+    def _settings(self) -> dict[str, Any]:
+        auto_refine: dict[str, Any] = {"enabled": self._auto_refine, "compact": self._auto_refine}
+        if self._refine_turn_interval is not None:
+            auto_refine["turnInterval"] = self._refine_turn_interval
+        if self._refine_cooldown_ms is not None:
+            auto_refine["cooldownMs"] = self._refine_cooldown_ms
+        return {"autoRefine": auto_refine}
+
+    async def _hydrate_agent_dir(self, environment) -> None:
+        agent_dir = shlex.quote(self._agent_dir)
+        await self.exec_as_agent(environment, command=f"mkdir -p {agent_dir}/harness")
+
+        if self._auth_json_path is not None:
+            if not self._auth_json_path.is_file():
+                raise PrimeRuntimeMissingError(f"auth_json_path does not exist: {self._auth_json_path}")
+            await environment.upload_file(self._auth_json_path, f"{self._agent_dir}/auth.json")
+
+        settings = shlex.quote(json.dumps(self._settings(), indent=2))
+        await self.exec_as_agent(
+            environment,
+            command=f"printf '%s' {settings} > {agent_dir}/settings.json",
+        )
+
+        if self._harness_state_path is not None:
+            if not self._harness_state_path.is_file():
+                raise PrimeRuntimeMissingError(f"harness_state_path does not exist: {self._harness_state_path}")
+            await environment.upload_file(
+                self._harness_state_path,
+                f"{self._agent_dir}/harness/harness_state.json",
+            )
+
+    @with_prompt_template
+    async def run(self, instruction: str, environment, context: AgentContext) -> None:
+        if not self.model_name or "/" not in self.model_name:
+            raise ValueError("Model name must be in the format provider/model_name")
+        provider, model = self.model_name.split("/", 1)
+
+        await self._hydrate_agent_dir(environment)
+
+        env = {**self._proxy_env(), "PRIME_AGENT_CODING_AGENT_DIR": self._agent_dir}
+        if self._runtime_prefix:
+            # Naming the interpreter is what skips auto-bootstrap. Pointing only
+            # at the venv makes Prime re-check the runtime and demand `uv`, which
+            # a task image will not have.
+            env["PRIME_AGENT_KERNEL_PYTHON"] = f"{self._kernel_venv_dir}/bin/python"
+            env["PRIME_AGENT_KERNEL_VENV"] = self._kernel_venv_dir
+        for key in ("PRIME_API_KEY", "OPENAI_API_KEY", "ANTHROPIC_API_KEY"):
+            if value := self._get_env(key):
+                env[key] = value
+
+        # A session is required for refinement to happen at all; a frozen run
+        # stays sessionless so it cannot persist anything.
+        session = f"--session-dir {shlex.quote(self._agent_dir)}/sessions" if self._auto_refine else "--no-session"
+        cli_flags = self.build_cli_flags()
+
+        await self.exec_as_agent(
+            environment,
+            command=(
+                f"{self._path_export()} "
+                f"prime-agent --print --mode json {session} "
+                f"--provider {shlex.quote(provider)} --model {shlex.quote(model)} "
+                f"{cli_flags + ' ' if cli_flags else ''}"
+                f"{shlex.quote(instruction)} "
+                f"2>&1 </dev/null | stdbuf -oL tee /logs/agent/{OUTPUT_FILENAME}"
+            ),
+            env=env,
+        )
+
+        if self._export_agent_dir:
+            # Captures harness_state.json plus anything the run persisted, so a
+            # checkpoint chain can be rebuilt on the host afterwards.
+            await environment.download_dir(self._agent_dir, self.logs_dir / EXPORT_DIRNAME)
+
+    def populate_context_post_run(self, context: AgentContext) -> None:
+        output_file = self.logs_dir / OUTPUT_FILENAME
+        if not output_file.exists():
+            return
+
+        input_tokens = output_tokens = cache_read_tokens = 0
+        total_cost = 0.0
+        for line in output_file.read_text().splitlines():
+            if not (line := line.strip()):
+                continue
+            try:
+                event = json.loads(line)
+            except (json.JSONDecodeError, TypeError):
+                continue
+            if event.get("type") != "message_end":
+                continue
+            message = event.get("message") or {}
+            if message.get("role") != "assistant":
+                continue
+            usage = message.get("usage") or {}
+            input_tokens += usage.get("input", 0)
+            output_tokens += usage.get("output", 0)
+            cache_read_tokens += usage.get("cacheRead", 0)
+            total_cost += (usage.get("cost") or {}).get("total", 0.0)
+
+        context.n_input_tokens = input_tokens + cache_read_tokens
+        context.n_output_tokens = output_tokens
+        context.n_cache_tokens = cache_read_tokens
+        context.cost_usd = total_cost if total_cost > 0 else None

--- a/src/evolve/integrations/harbor/prime_agent.py
+++ b/src/evolve/integrations/harbor/prime_agent.py
@@ -179,9 +179,9 @@ class PrimeAgent(BaseInstalledAgent):
 
     @with_prompt_template
     async def run(self, instruction: str, environment, context: AgentContext) -> None:
-        if not self.model_name or "/" not in self.model_name:
+        provider, separator, model = (self.model_name or "").partition("/")
+        if not separator or not provider or not model:
             raise ValueError("Model name must be in the format provider/model_name")
-        provider, model = self.model_name.split("/", 1)
 
         await self._hydrate_agent_dir(environment)
 
@@ -204,6 +204,10 @@ class PrimeAgent(BaseInstalledAgent):
         await self.exec_as_agent(
             environment,
             command=(
+                # `tee` is last in the pipeline, so without pipefail a crashed or
+                # unauthenticated prime-agent still reports success and Harbor
+                # scores the trial as a completed run.
+                "set -o pipefail; "
                 f"{self._path_export()} "
                 f"prime-agent --print --mode json {session} "
                 f"--provider {shlex.quote(provider)} --model {shlex.quote(model)} "
@@ -215,6 +219,13 @@ class PrimeAgent(BaseInstalledAgent):
         )
 
         if self._export_agent_dir:
+            # Credentials must not outlive the trial: the export is a Harbor
+            # artifact that gets retained and shared, so drop auth.json before
+            # the directory leaves the container.
+            await self.exec_as_agent(
+                environment,
+                command=f"rm -f {shlex.quote(self._agent_dir)}/auth.json",
+            )
             # Captures harness_state.json plus anything the run persisted, so a
             # checkpoint chain can be rebuilt on the host afterwards.
             await environment.download_dir(self._agent_dir, self.logs_dir / EXPORT_DIRNAME)

--- a/tests/test_prime_agent.py
+++ b/tests/test_prime_agent.py
@@ -106,7 +106,7 @@ def test_session_is_kept_only_when_refinement_is_expected(monkeypatch, auto_refi
 
     asyncio.run(_run(agent, environment))
 
-    run_command = agent.agent_commands[-1]
+    run_command = next(c for c in agent.agent_commands if "prime-agent --print" in c)
     assert expected in run_command
     assert forbidden not in run_command
 
@@ -243,11 +243,51 @@ def test_usage_is_summed_from_message_end_events(monkeypatch, tmp_path) -> None:
     assert context.cost_usd == pytest.approx(0.75)
 
 
-def test_model_name_must_carry_a_provider(monkeypatch) -> None:
+@pytest.mark.parametrize("model_name", ["gpt-without-provider", "/gpt", "openai/", "", None])
+def test_model_name_must_carry_both_provider_and_model(monkeypatch, model_name) -> None:
     module = _load(monkeypatch)
-    agent = module.PrimeAgent(model_name="gpt-without-provider")
+    agent = module.PrimeAgent(model_name=model_name)
 
     import asyncio
 
     with pytest.raises(ValueError, match="provider/model_name"):
         asyncio.run(_run(agent, FakeEnvironment()))
+
+
+def test_agent_failure_is_not_masked_by_tee(monkeypatch) -> None:
+    """`tee` closes the pipeline, so without pipefail a failed prime-agent run
+    reports success and Harbor scores it as a completed trial."""
+    module = _load(monkeypatch)
+    agent = module.PrimeAgent(model_name="openai/gpt")
+
+    import asyncio
+
+    asyncio.run(_run(agent, FakeEnvironment()))
+
+    run_command = next(c for c in agent.agent_commands if "prime-agent --print" in c)
+    assert "set -o pipefail" in run_command
+    assert run_command.index("set -o pipefail") < run_command.index("| stdbuf")
+
+
+def test_credentials_are_removed_before_the_export(monkeypatch, tmp_path) -> None:
+    """The export becomes a retained Harbor artifact, so auth.json must not
+    survive into it."""
+    module = _load(monkeypatch)
+    auth = tmp_path / "auth.json"
+    auth.write_text(json.dumps({"openai-codex": {"access": "secret"}}))
+    agent = module.PrimeAgent(model_name="openai/gpt", auth_json_path=auth, logs_dir=tmp_path / "logs")
+    environment = FakeEnvironment()
+
+    import asyncio
+
+    asyncio.run(_run(agent, environment))
+
+    assert (auth, "/tmp/prime-agent-dir/auth.json") in environment.uploads
+    removal = "rm -f /tmp/prime-agent-dir/auth.json"
+    assert any(removal in command for command in agent.agent_commands)
+    # …and it must happen before the directory leaves the container.
+    assert (
+        agent.agent_commands.index(next(c for c in agent.agent_commands if removal in c))
+        == len(agent.agent_commands) - 1
+    )
+    assert environment.downloads == [("/tmp/prime-agent-dir", tmp_path / "logs" / "prime-agent-dir")]

--- a/tests/test_prime_agent.py
+++ b/tests/test_prime_agent.py
@@ -18,6 +18,9 @@ class FakeBaseInstalledAgent:
         self.logs_dir = Path(kwargs.get("logs_dir") or ".")
         self.model_name = kwargs.get("model_name")
         self._extra_env = dict(kwargs.get("extra_env") or {})
+        # Shared with FakeEnvironment so ordering between exec and transfer is
+        # observable; two separate lists cannot prove one preceded the other.
+        self.events: list[tuple[str, str]] = []
         self.agent_commands: list[str] = []
         self.root_commands: list[str] = []
         self.agent_envs: list[dict[str, str]] = []
@@ -32,6 +35,7 @@ class FakeBaseInstalledAgent:
         del environment
         self.agent_commands.append(command)
         self.agent_envs.append(dict(env or {}))
+        self.events.append(("exec", command))
 
     async def exec_as_root(self, environment, command: str, env: dict[str, str] | None = None) -> None:
         del environment, env
@@ -44,15 +48,18 @@ class FakeCliFlag:
 
 
 class FakeEnvironment:
-    def __init__(self) -> None:
+    def __init__(self, events: list[tuple[str, str]] | None = None) -> None:
         self.uploads: list[tuple[Path, str]] = []
         self.downloads: list[tuple[str, Path]] = []
+        self.events = events if events is not None else []
 
     async def upload_file(self, source, target: str) -> None:
         self.uploads.append((Path(source), target))
+        self.events.append(("upload", target))
 
     async def download_dir(self, source: str, target) -> None:
         self.downloads.append((source, Path(target)))
+        self.events.append(("download", source))
 
 
 def _load(monkeypatch):
@@ -270,24 +277,24 @@ def test_agent_failure_is_not_masked_by_tee(monkeypatch) -> None:
 
 
 def test_credentials_are_removed_before_the_export(monkeypatch, tmp_path) -> None:
-    """The export becomes a retained Harbor artifact, so auth.json must not
-    survive into it."""
+    """The export becomes a retained Harbor artifact, so auth.json must be gone
+    from the agent directory *before* the directory is downloaded."""
     module = _load(monkeypatch)
     auth = tmp_path / "auth.json"
     auth.write_text(json.dumps({"openai-codex": {"access": "secret"}}))
     agent = module.PrimeAgent(model_name="openai/gpt", auth_json_path=auth, logs_dir=tmp_path / "logs")
-    environment = FakeEnvironment()
+    environment = FakeEnvironment(events=agent.events)
 
     import asyncio
 
     asyncio.run(_run(agent, environment))
 
-    assert (auth, "/tmp/prime-agent-dir/auth.json") in environment.uploads
-    removal = "rm -f /tmp/prime-agent-dir/auth.json"
-    assert any(removal in command for command in agent.agent_commands)
-    # …and it must happen before the directory leaves the container.
-    assert (
-        agent.agent_commands.index(next(c for c in agent.agent_commands if removal in c))
-        == len(agent.agent_commands) - 1
+    kinds = [kind for kind, _ in agent.events]
+    removal = next(
+        index
+        for index, (kind, detail) in enumerate(agent.events)
+        if kind == "exec" and "rm -f /tmp/prime-agent-dir/auth.json" in detail
     )
+    export = kinds.index("download")
+    assert removal < export, agent.events
     assert environment.downloads == [("/tmp/prime-agent-dir", tmp_path / "logs" / "prime-agent-dir")]

--- a/tests/test_prime_agent.py
+++ b/tests/test_prime_agent.py
@@ -1,0 +1,253 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+ADAPTER = ROOT / "src" / "evolve" / "integrations" / "harbor" / "prime_agent.py"
+
+
+class FakeBaseInstalledAgent:
+    def __init__(self, *args, **kwargs) -> None:
+        del args
+        self.logs_dir = Path(kwargs.get("logs_dir") or ".")
+        self.model_name = kwargs.get("model_name")
+        self._extra_env = dict(kwargs.get("extra_env") or {})
+        self.agent_commands: list[str] = []
+        self.root_commands: list[str] = []
+        self.agent_envs: list[dict[str, str]] = []
+
+    def _get_env(self, name: str) -> str | None:
+        return self._extra_env.get(name)
+
+    def build_cli_flags(self) -> str:
+        return ""
+
+    async def exec_as_agent(self, environment, command: str, env: dict[str, str] | None = None) -> None:
+        del environment
+        self.agent_commands.append(command)
+        self.agent_envs.append(dict(env or {}))
+
+    async def exec_as_root(self, environment, command: str, env: dict[str, str] | None = None) -> None:
+        del environment, env
+        self.root_commands.append(command)
+
+
+class FakeCliFlag:
+    def __init__(self, *args, **kwargs) -> None:
+        del args, kwargs
+
+
+class FakeEnvironment:
+    def __init__(self) -> None:
+        self.uploads: list[tuple[Path, str]] = []
+        self.downloads: list[tuple[str, Path]] = []
+
+    async def upload_file(self, source, target: str) -> None:
+        self.uploads.append((Path(source), target))
+
+    async def download_dir(self, source: str, target) -> None:
+        self.downloads.append((source, Path(target)))
+
+
+def _load(monkeypatch):
+    base = ModuleType("harbor.agents.installed.base")
+    base.BaseInstalledAgent = FakeBaseInstalledAgent
+    base.CliFlag = FakeCliFlag
+    base.with_prompt_template = lambda fn: fn
+
+    node_install = ModuleType("harbor.agents.installed.node_install")
+    node_install.nvm_node_install_snippet = lambda: "install-node"
+
+    context = ModuleType("harbor.models.agent.context")
+    context.AgentContext = object
+
+    modules = {
+        "harbor": ModuleType("harbor"),
+        "harbor.agents": ModuleType("harbor.agents"),
+        "harbor.agents.installed": ModuleType("harbor.agents.installed"),
+        "harbor.agents.installed.base": base,
+        "harbor.agents.installed.node_install": node_install,
+        "harbor.models": ModuleType("harbor.models"),
+        "harbor.models.agent": ModuleType("harbor.models.agent"),
+        "harbor.models.agent.context": context,
+    }
+    for name, module in modules.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    spec = importlib.util.spec_from_file_location("evolve.integrations.harbor.prime_agent", ADAPTER)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+async def _run(agent, environment) -> None:
+    await agent.run("solve it", environment, context=None)
+
+
+@pytest.mark.parametrize(
+    ("auto_refine", "expected", "forbidden"),
+    [(False, "--no-session", "--session-dir"), (True, "--session-dir", "--no-session")],
+)
+def test_session_is_kept_only_when_refinement_is_expected(monkeypatch, auto_refine, expected, forbidden) -> None:
+    """Prime gates auto-refine on a session-local harness dir, so `--no-session`
+    disables refinement structurally regardless of the autoRefine settings."""
+    module = _load(monkeypatch)
+    agent = module.PrimeAgent(model_name="openai/gpt", auto_refine=auto_refine)
+    environment = FakeEnvironment()
+
+    import asyncio
+
+    asyncio.run(_run(agent, environment))
+
+    run_command = agent.agent_commands[-1]
+    assert expected in run_command
+    assert forbidden not in run_command
+
+
+def test_refine_thresholds_are_written_into_settings(monkeypatch) -> None:
+    """Prime ships turnInterval=25 and a 20 minute cooldown, which never fire on
+    a short episode; the thresholds must be explicit to be reproducible."""
+    module = _load(monkeypatch)
+    agent = module.PrimeAgent(
+        model_name="openai/gpt",
+        auto_refine=True,
+        refine_turn_interval=1,
+        refine_cooldown_ms=0,
+    )
+
+    settings = agent._settings()["autoRefine"]
+
+    assert settings == {"enabled": True, "compact": True, "turnInterval": 1, "cooldownMs": 0}
+
+
+def test_settings_omit_thresholds_when_unset(monkeypatch) -> None:
+    module = _load(monkeypatch)
+    agent = module.PrimeAgent(model_name="openai/gpt")
+
+    assert agent._settings()["autoRefine"] == {"enabled": False, "compact": False}
+
+
+def test_version_command_captures_stderr(monkeypatch) -> None:
+    """prime-agent prints its version on stderr; without the redirect Harbor
+    records the agent version as "unknown"."""
+    module = _load(monkeypatch)
+    agent = module.PrimeAgent(model_name="openai/gpt")
+
+    assert agent.get_version_command().endswith("prime-agent --version 2>&1")
+
+
+def test_runtime_prefix_skips_network_install(monkeypatch) -> None:
+    module = _load(monkeypatch)
+    agent = module.PrimeAgent(model_name="openai/gpt", runtime_prefix="/opt/prime-runtime")
+    environment = FakeEnvironment()
+
+    import asyncio
+
+    asyncio.run(agent.install(environment))
+
+    assert agent.root_commands == []
+    install_command = agent.agent_commands[-1]
+    assert "install-node" not in install_command
+    assert "/opt/prime-runtime/bin/prime-agent" in install_command
+    # The kernel venv needs a writable copy: Prime writes a bootstrap lock next
+    # to it, which fails on a read-only mount.
+    assert "cp -a /opt/prime-runtime/kernel-venv" in install_command
+
+
+def test_network_install_used_without_runtime_prefix(monkeypatch) -> None:
+    module = _load(monkeypatch)
+    agent = module.PrimeAgent(model_name="openai/gpt")
+    environment = FakeEnvironment()
+
+    import asyncio
+
+    asyncio.run(agent.install(environment))
+
+    assert any("apt-get" in command for command in agent.root_commands)
+    assert "install-node" in agent.agent_commands[-1]
+
+
+def test_harness_state_is_uploaded_and_agent_dir_exported(monkeypatch, tmp_path) -> None:
+    module = _load(monkeypatch)
+    harness = tmp_path / "harness_state.json"
+    harness.write_text(json.dumps({"schema": 1, "entries": {}}))
+    agent = module.PrimeAgent(
+        model_name="openai/gpt",
+        harness_state_path=harness,
+        logs_dir=tmp_path / "logs",
+    )
+    environment = FakeEnvironment()
+
+    import asyncio
+
+    asyncio.run(_run(agent, environment))
+
+    assert (harness, "/tmp/prime-agent-dir/harness/harness_state.json") in environment.uploads
+    assert environment.downloads == [("/tmp/prime-agent-dir", tmp_path / "logs" / "prime-agent-dir")]
+
+
+def test_missing_harness_state_fails_closed(monkeypatch, tmp_path) -> None:
+    module = _load(monkeypatch)
+    agent = module.PrimeAgent(model_name="openai/gpt", harness_state_path=tmp_path / "absent.json")
+
+    import asyncio
+
+    with pytest.raises(module.PrimeRuntimeMissingError, match="harness_state_path"):
+        asyncio.run(_run(agent, FakeEnvironment()))
+
+
+def test_usage_is_summed_from_message_end_events(monkeypatch, tmp_path) -> None:
+    module = _load(monkeypatch)
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    events = [
+        {"type": "message_start", "message": {"role": "assistant"}},
+        {
+            "type": "message_end",
+            "message": {
+                "role": "assistant",
+                "usage": {"input": 100, "output": 20, "cacheRead": 5, "cost": {"total": 0.5}},
+            },
+        },
+        {
+            "type": "message_end",
+            "message": {
+                "role": "assistant",
+                "usage": {"input": 40, "output": 10, "cacheRead": 1, "cost": {"total": 0.25}},
+            },
+        },
+        {"type": "message_end", "message": {"role": "toolResult", "usage": {"input": 999}}},
+        "not json",
+    ]
+    (logs / "prime-agent.jsonl").write_text(
+        "\n".join(event if isinstance(event, str) else json.dumps(event) for event in events)
+    )
+    agent = module.PrimeAgent(model_name="openai/gpt", logs_dir=logs)
+
+    class Context:
+        pass
+
+    context = Context()
+    agent.populate_context_post_run(context)
+
+    assert context.n_input_tokens == 146
+    assert context.n_output_tokens == 30
+    assert context.n_cache_tokens == 6
+    assert context.cost_usd == pytest.approx(0.75)
+
+
+def test_model_name_must_carry_a_provider(monkeypatch) -> None:
+    module = _load(monkeypatch)
+    agent = module.PrimeAgent(model_name="gpt-without-provider")
+
+    import asyncio
+
+    with pytest.raises(ValueError, match="provider/model_name"):
+        asyncio.run(_run(agent, FakeEnvironment()))

--- a/tests/test_recipe_composition.py
+++ b/tests/test_recipe_composition.py
@@ -12,7 +12,10 @@ from evolve.config import RECIPE_NAMES, default_config, load_config, recipe_root
 from evolve.workspace import InitOptions, _write_target, init_workspace
 
 CANDIDATE = "evolve.integrations.harbor.miniswe_candidate:CandidateMiniSweAgent"
-OPTIONAL_INTEGRATIONS = {"evolve.integrations.harbor.codex_candidate"}
+OPTIONAL_INTEGRATIONS = {
+    "evolve.integrations.harbor.codex_candidate",
+    "evolve.integrations.harbor.prime_agent",
+}
 FILE_TASK = "evolve.integrations.harbor.miniswe_task_file:InstalledMiniSweAgent"
 ANSI_ESCAPE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
 CASES = {


### PR DESCRIPTION
Adds `evolve.integrations.harbor.prime_agent:PrimeAgent` so EvolveX can evaluate
[Prime Agent](https://github.com/PrimeIntellect-ai/prime-agent) — and, more
interestingly, measure its **continual harness** across a chain of generations.

## Why it is small

Prime Agent descends from `badlogic/pi-mono` and kept that CLI contract, so the
invocation and the `message_end` usage accounting mirror Harbor's existing `pi`
adapter. The Prime-specific part is the harness: the adapter can pin a trial to
a checkpoint and export whatever the run persisted, which is what makes a
generation chain observable at all.

## Two upstream behaviours that fail silently

Both were found the hard way while running Terminal-Bench 2.0, and both are
handled explicitly rather than left to the caller:

- **`--no-session` disables refinement structurally.** Prime gates auto-refine
  on a session-local harness directory, so a sessionless run never refines no
  matter how `autoRefine` is configured. Nothing about it looks wrong — reward,
  trajectory and exit status are all normal — it simply never learns. Sessions
  are kept when refinement is expected; frozen and probe runs stay sessionless
  so they cannot persist anything.
- **The shipped thresholds never fire on a benchmark.** Prime defaults to
  `turnInterval=25` and a 20 minute cooldown, while these episodes finish in a
  handful of turns. `refine_turn_interval` / `refine_cooldown_ms` make that an
  explicit experiment parameter, because "measure shipped behaviour" and
  "measure refinement" are different questions with different answers.

## Restricted networks

`runtime_prefix` accepts a pre-baked runtime mounted read-only, for environments
where Prime's postinstall cannot reach the release CDNs it provisions Python
from. `install()` then degrades to a version check and the trial needs no
network for the agent itself. Pinning the bundle digest also fixes Node, Prime
Agent and the Python runtime together, which is a stronger guarantee than a
version string when arms of an experiment run on different days.

## Contents

| Path | |
| --- | --- |
| `src/evolve/integrations/harbor/prime_agent.py` | the adapter |
| `tests/test_prime_agent.py` | 11 tests, harbor stubbed following `test_codex_candidate.py` |
| `docs/guides/prime-agent.md` | usage, the two gotchas, and the runtime bundle |
| `ARCHITECTURE.md`, `mkdocs.yml`, `tests/test_recipe_composition.py` | inventory registration |

The guide also documents a consequence worth knowing before interpreting a
multi-episode result: refinement lands in the **session-local** harness, so an
export contains both the injected parent copy and the episode's own store.
Carrying a chain forward means merging them — preferring the global file
replays the parent unchanged, and preferring the session-local file discards
everything learned earlier. Either mistake yields a checkpoint chain that reads
as a healthy learning curve while nothing accumulates.

## Checks

`ruff check` · `ruff format --check` · `ty check` · `uv lock --check` ·
`pytest -q` → 964 passed, 3 skipped.

Exercised end-to-end against Terminal-Bench 2.0 (89 tasks) on Docker, including
a 16-generation harness chain and a held-out sealed comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Prime Agent integration with configurable reasoning, refinement, authentication, sessions, runtime selection, and usage tracking.
  - Added harness checkpoint import and export across runs.
  - Added prebuilt-runtime support for restricted network environments.
  - Added secure credential handling when exporting artifacts.

- **Documentation**
  - Added a Prime Agent setup and usage guide covering CLI and recipe configuration.
  - Added the guide to the documentation navigation.

- **Bug Fixes**
  - Added clear validation and errors for missing runtimes, state files, and invalid model providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->