### PR TITLE
Rename project identity to RSIHub

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,5 +1,5 @@
 name: Bug report
-description: Report a reproducible defect in EvolveX.
+description: Report a reproducible defect in RSIHub.
 title: "[Bug]: "
 labels: [bug]
 body:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Security vulnerability
-    url: https://github.com/simple-agent-lab/EvolveX/security/advisories/new
+    url: https://github.com/simple-agent-lab/RSIHub/security/advisories/new
     about: Report suspected vulnerabilities privately instead of opening an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,5 @@
 name: Feature request
-description: Propose a scoped improvement to EvolveX.
+description: Propose a scoped improvement to RSIHub.
 title: "[Feature]: "
 labels: [enhancement]
 body:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,8 +79,8 @@ jobs:
       # runner has no global one — configure it so any stray git op still works.
       - name: Configure git identity
         run: |
-          git config --global user.name "evolvex-ci"
-          git config --global user.email "evolvex-ci@example.invalid"
+          git config --global user.name "rsihub-ci"
+          git config --global user.email "rsihub-ci@example.invalid"
           git config --global init.defaultBranch main
 
       # The default tier is the coherence guard (ARCHITECTURE + line budgets +
@@ -151,5 +151,5 @@ jobs:
           # packaging and workspace scaffolding, not registry connectivity.
           EVAL_STUB=1 EVOLVE_HOME="$RUNNER_TEMP/wheel-smoke-home" EVOLVE_RUNTIME_DIGEST="sha256:release-artifact-smoke" "$GITHUB_WORKSPACE/.venv/bin/evolve" init "$RUNNER_TEMP/wheel-smoke" --recipe aevolve
           EVOLVE_HOME="$RUNNER_TEMP/wheel-smoke-home" "$GITHUB_WORKSPACE/.venv/bin/evolve" status "$RUNNER_TEMP/wheel-smoke"
-          test -f "$RUNNER_TEMP/wheel-smoke/LICENSE.evolvex"
-          test -f "$RUNNER_TEMP/wheel-smoke/NOTICE.evolvex"
+          test -f "$RUNNER_TEMP/wheel-smoke/LICENSE.rsihub"
+          test -f "$RUNNER_TEMP/wheel-smoke/NOTICE.rsihub"

--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,7 @@ junit.xml
 !.env.example
 *.local
 
-# EvolveX runtime artifacts
+# RSIHub runtime artifacts
 runs/
 archive.jsonl
 .evolve-eval-receipts.jsonl

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -59,7 +59,7 @@ appointed representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported privately through the [GitHub private reporting channel](https://github.com/simple-agent-lab/EvolveX/security/advisories/new)
+reported privately through the [GitHub private reporting channel](https://github.com/simple-agent-lab/RSIHub/security/advisories/new)
 described in [the security policy](SECURITY.md). All complaints will be
 reviewed and investigated promptly and fairly.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Thank you for improving EvolveX. Read [the design guide](docs/concepts/design.md),
+Thank you for improving RSIHub. Read [the design guide](docs/concepts/design.md),
 [ARCHITECTURE.md](ARCHITECTURE.md), and [the coding style](docs/development/coding-style.md)
 before making a non-trivial change.
 

--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
-EvolveX
-Copyright 2026 Simple Agent Lab and the EvolveX authors
+RSIHub
+Copyright 2026 Simple Agent Lab and the RSIHub authors
 
 This product includes software developed at Simple Agent Lab.
 

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -5,8 +5,8 @@ Terminal-Bench 2.0 subset. The launcher requires Bash, Python 3.12+,
 [`uv`](https://docs.astral.sh/uv/), Git 2.25+, and a running Docker daemon.
 
 ```bash
-git clone https://github.com/simple-agent-lab/EvolveX.git
-cd EvolveX
+git clone https://github.com/simple-agent-lab/RSIHub.git
+cd RSIHub
 
 # API authentication is the default. Keep credentials out of recipe YAML.
 cat > .env <<'EOF'

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 <p align="center">
-  <img src="docs/evolve-mark.svg" width="112" alt="EvolveX selected lineage mark: a selected lineage rises past explored side branches to a verified generation.">
+  <img src="docs/rsihub-mark.svg" width="112" alt="RSIHub selected lineage mark: a selected lineage rises past explored side branches to a verified generation.">
 </p>
 
-<h1 align="center">EvolveX</h1>
+<h1 align="center">RSIHub</h1>
 
 <p align="center">
   <strong>Build agents that improve — and keep the evidence.</strong>
@@ -14,8 +14,8 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/simple-agent-lab/EvolveX/actions/workflows/test.yml">
-    <img alt="Tests" src="https://github.com/simple-agent-lab/EvolveX/actions/workflows/test.yml/badge.svg">
+  <a href="https://github.com/simple-agent-lab/RSIHub/actions/workflows/test.yml">
+    <img alt="RSIHub tests" src="https://github.com/simple-agent-lab/RSIHub/actions/workflows/test.yml/badge.svg">
   </a>
   <a href="https://www.python.org/">
     <img alt="Python 3.12+" src="https://img.shields.io/badge/Python-3.12%2B-3776AB?logo=python&amp;logoColor=white">
@@ -23,14 +23,14 @@
   <a href="LICENSE">
     <img alt="Apache-2.0 License" src="https://img.shields.io/badge/License-Apache--2.0-blue.svg">
   </a>
-  <a href="https://simple-agent-lab.github.io/EvolveX/">
-    <img alt="Documentation" src="https://img.shields.io/badge/Documentation-EvolveX-0F766E?logo=materialformkdocs&amp;logoColor=white">
+  <a href="https://simple-agent-lab.github.io/RSIHub/">
+    <img alt="RSIHub documentation" src="https://img.shields.io/badge/Documentation-RSIHub-0F766E?logo=materialformkdocs&amp;logoColor=white">
   </a>
 </p>
 
 <p align="center">
-  <a href="#what-evolvex-does">What EvolveX Does</a> ·
-  <a href="#how-evolvex-works">How It Works</a> ·
+  <a href="#what-rsihub-does">What RSIHub Does</a> ·
+  <a href="#how-rsihub-works">How It Works</a> ·
   <a href="#what-can-evolve">What Can Evolve</a> ·
   <a href="#recipes">Recipes</a> ·
   <a href="#skill-evolution-showcase">Showcase</a> ·
@@ -50,9 +50,9 @@
   </a>
 </p>
 
-## What EvolveX Does
+## What RSIHub Does
 
-EvolveX gives an agent a controlled way to improve itself. It runs candidates
+RSIHub gives an agent a controlled way to improve itself. It runs candidates
 against a fixed evaluator, keeps the evidence for every generation, and carries
 verified improvements forward without letting candidate code rewrite the rules
 that score it.
@@ -64,7 +64,7 @@ that score it.
 - **Evidence built in:** Connect every candidate to scores, artifacts, archive
   records, and Git lineage.
 
-## How EvolveX Works
+## How RSIHub Works
 
 Every recipe composes the same loop:
 
@@ -74,7 +74,7 @@ Every recipe composes the same loop:
 
 <p align="center">
   <a href="docs/assets/architecture.svg">
-    <img src="docs/assets/architecture.svg" alt="EvolveX architecture: five built-in strategies and custom recipes compose a loop of select, rollout and evaluation, analyze, mutate, gate, and record. The target and selected operators occupy a declared mutable surface. The evaluator, runtime, surface check, and stamped evidence remain protected from candidate changes.">
+    <img src="docs/assets/architecture.svg" alt="RSIHub architecture: five built-in strategies and custom recipes compose a loop of select, rollout and evaluation, analyze, mutate, gate, and record. The target and selected operators occupy a declared mutable surface. The evaluator, runtime, surface check, and stamped evidence remain protected from candidate changes.">
   </a>
 </p>
 
@@ -108,7 +108,7 @@ See [the recipe guide](recipes/README.md) for each strategy’s workflow and con
 
 ## Skill Evolution Showcase
 
-EvolveX can improve a Skill as a complete package: instructions, references,
+RSIHub can improve a Skill as a complete package: instructions, references,
 and validation scripts evolve together while a frozen evaluator keeps the
 comparison honest. In this local Paper2Poster run, the same Codex model and
 paper prompt produced both LoRA posters below.
@@ -288,7 +288,7 @@ Split: **50 train / 20 gate / 27 sealed**.
 
 ## Trustworthy by Construction
 
-EvolveX separates evolvable policy from the mechanism that judges it:
+RSIHub separates evolvable policy from the mechanism that judges it:
 
 1. **The evaluator is frozen.** Candidates cannot change the scoring contract.
 2. **Mutation is bounded.** Each recipe declares which target and operator paths may change.
@@ -300,7 +300,7 @@ process. See [the design guide](docs/concepts/design.md) for the complete owners
 
 ## Project Status
 
-EvolveX is an active prototype for research and controlled experimentation. The
+RSIHub is an active prototype for research and controlled experimentation. The
 current focus is reliable experiment mechanics, local-first workflows, and
 composable strategies for different agent-evolution scenarios.
 
@@ -317,7 +317,7 @@ composable strategies for different agent-evolution scenarios.
 
 | Document | Purpose |
 | --- | --- |
-| [Documentation site](https://simple-agent-lab.github.io/EvolveX/) | Installation, operation, concepts, guides, and reference. |
+| [Documentation site](https://simple-agent-lab.github.io/RSIHub/) | Installation, operation, concepts, guides, and reference. |
 | [Quick start](QUICKSTART.md) | Recipe launcher setup and configuration. |
 | [Design](docs/concepts/design.md) | System model, ownership boundaries, and invariants. |
 | [Architecture](ARCHITECTURE.md) | Enforced source-module map and line budgets. |
@@ -332,5 +332,5 @@ composable strategies for different agent-evolution scenarios.
 
 ## License
 
-EvolveX is licensed under [Apache-2.0](LICENSE). See
+RSIHub is licensed under [Apache-2.0](LICENSE). See
 [NOTICE](NOTICE) for required attributions.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ is supported with security fixes.
 ## Reporting a vulnerability
 
 Do not open a public issue for a suspected vulnerability. Submit it through
-[GitHub private vulnerability reporting](https://github.com/simple-agent-lab/EvolveX/security/advisories/new).
+[GitHub private vulnerability reporting](https://github.com/simple-agent-lab/RSIHub/security/advisories/new).
 
 Repository maintainers aim to acknowledge reports within three business days
 and provide a status update within seven business days. Disclosure timing is

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,11 +1,11 @@
 # Support
 
-Search [existing issues](https://github.com/simple-agent-lab/EvolveX/issues)
+Search [existing issues](https://github.com/simple-agent-lab/RSIHub/issues)
 before filing. Use the
-[bug report form](https://github.com/simple-agent-lab/EvolveX/issues/new?template=bug_report.yml)
+[bug report form](https://github.com/simple-agent-lab/RSIHub/issues/new?template=bug_report.yml)
 for reproducible defects and include the framework version, recipe, environment,
 and a minimal reproducer. Use the
-[feature request form](https://github.com/simple-agent-lab/EvolveX/issues/new?template=feature_request.yml)
+[feature request form](https://github.com/simple-agent-lab/RSIHub/issues/new?template=feature_request.yml)
 for scoped enhancements.
 
 For suspected vulnerabilities, follow [the security policy](SECURITY.md) and

--- a/docs/assets/architecture.svg
+++ b/docs/assets/architecture.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1240" height="520" viewBox="0 0 1240 520" role="img" aria-labelledby="title description">
-  <title id="title">EvolveX architecture</title>
+  <title id="title">RSIHub architecture</title>
   <desc id="description">Evolution methods such as Hill Climb, A-Evolve, AHE, GEPA and HyperAgents plug into one loop of select, rollout, analyze, mutate, gate and record. The loop and the agent it improves sit inside a declared mutable surface. Recipes select permitted targets, operators, and stages. Only the substrate below stays frozen: the evaluator, the runtime, the surface check and the stamped evidence.</desc>
   <style>
     text { font-family: "Noto Sans SC", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; fill: #18362b; }

--- a/docs/assets/benchmark-results.svg
+++ b/docs/assets/benchmark-results.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1600" height="790" viewBox="0 0 1600 790" role="img" aria-labelledby="title desc">
-<title id="title">EvolveX benchmark results</title>
+<title id="title">RSIHub benchmark results</title>
 <desc id="desc">Terminal Bench 2 and Tau cubed Banking results for four evolution methods with MiniSWE and Codex target agents. MiniSWE is grouped left and Codex right in each panel. The vertical axes use truncated ranges (50–80% and 20–50%). Dark bar sections show seed scores above each axis baseline; light sections show improvement to the best score.</desc>
 <rect width="1600" height="790" rx="18" fill="#FFFFFF"/>
 <style>text{font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}.title{font-size:25px;font-weight:750;fill:#0F172A}.axis{font-size:12px;fill:#64748B}.method{font-size:16px;font-weight:750;fill:#334155}.seed{font-size:16px;font-weight:800;fill:#FFFFFF}.best{font-size:16px;font-weight:800;fill:#0F172A}.delta-up{fill:#1A7F37}.delta-down{fill:#CF222E}.delta-flat{fill:#9A6700}.agent{font-size:17px;font-weight:800}.legend{font-size:13px;font-weight:650;fill:#334155}.note{font-size:12px;fill:#64748B}</style>

--- a/docs/assets/repository-stats.json
+++ b/docs/assets/repository-stats.json
@@ -1,7 +1,7 @@
 {
   "fetched_at": "2026-08-10T07:06:41.657569Z",
   "forks": 0,
-  "repository": "simple-agent-lab/EvolveX",
+  "repository": "simple-agent-lab/RSIHub",
   "schema_version": 1,
   "stars": 19
 }

--- a/docs/concepts/design.md
+++ b/docs/concepts/design.md
@@ -1,14 +1,14 @@
-# EvolveX design
+# RSIHub design
 
 This document describes the framework model and rationale. The executable
 module inventory lives in
-[ARCHITECTURE.md on GitHub](https://github.com/simple-agent-lab/EvolveX/blob/main/ARCHITECTURE.md);
+[ARCHITECTURE.md on GitHub](https://github.com/simple-agent-lab/RSIHub/blob/main/ARCHITECTURE.md);
 the operator contract in `src/evolve/frozen/interfaces.py` is authoritative for
 interfaces.
 
 ## The model
 
-EvolveX evolves a candidate under a frozen evaluator while retaining a Git
+RSIHub evolves a candidate under a frozen evaluator while retaining a Git
 lineage. A workspace is a separate Git repository: generation tags identify
 candidates, `archive.jsonl` records stamped outcomes, and the evaluator stays
 outside the candidate's mutable surface.

--- a/docs/development/coding-style.md
+++ b/docs/development/coding-style.md
@@ -3,7 +3,7 @@
 Binding ethos for code and prose. Architecture (where things live, what is
 frozen, operator contracts) lives in [the design guide](../concepts/design.md)
 and the
-[source architecture map](https://github.com/simple-agent-lab/EvolveX/blob/main/ARCHITECTURE.md).
+[source architecture map](https://github.com/simple-agent-lab/RSIHub/blob/main/ARCHITECTURE.md).
 This file is only *how* we write.
 
 Throughline: **don't trust discipline — build the constraint.** Prefer a rule a

--- a/docs/development/documentation.md
+++ b/docs/development/documentation.md
@@ -4,17 +4,17 @@ The maintained public documentation has distinct roles:
 
 | Document | Role |
 | --- | --- |
-| [Repository README](https://github.com/simple-agent-lab/EvolveX/blob/main/README.md) | concise repository overview and benchmark results |
-| [Quick start guide](https://github.com/simple-agent-lab/EvolveX/blob/main/QUICKSTART.md) | recipe launcher quick start |
+| [Repository README](https://github.com/simple-agent-lab/RSIHub/blob/main/README.md) | concise repository overview and benchmark results |
+| [Quick start guide](https://github.com/simple-agent-lab/RSIHub/blob/main/QUICKSTART.md) | recipe launcher quick start |
 | [`../index.md`](../index.md) | public documentation home |
 | [`../concepts/design.md`](../concepts/design.md) | framework model and ownership boundaries |
-| [Source architecture map](https://github.com/simple-agent-lab/EvolveX/blob/main/ARCHITECTURE.md) | enforced `src/evolve/` module map and budgets |
+| [Source architecture map](https://github.com/simple-agent-lab/RSIHub/blob/main/ARCHITECTURE.md) | enforced `src/evolve/` module map and budgets |
 | [`../reference/terminology.md`](../reference/terminology.md) | canonical framework language |
 | [`coding-style.md`](coding-style.md) | coding conventions |
-| [`../evolve-mark.svg`](../evolve-mark.svg) | generated Selected Lineage identity mark |
+| [`../rsihub-mark.svg`](../rsihub-mark.svg) | generated Selected Lineage identity mark |
 | [`../evolve-lineage.svg`](../evolve-lineage.svg) | generated README identity figure |
 | [`../assets/architecture.svg`](../assets/architecture.svg) | generated architecture diagram |
-| [Operator interfaces](https://github.com/simple-agent-lab/EvolveX/blob/main/src/evolve/frozen/interfaces.py) | machine-readable operator contract |
+| [Operator interfaces](https://github.com/simple-agent-lab/RSIHub/blob/main/src/evolve/frozen/interfaces.py) | machine-readable operator contract |
 
 Put dated proposals in `docs/designs/` and implementation plans in
 `docs/plans/`. Update the maintained document that describes a behavior in the

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,8 +10,8 @@
 ## Install for development
 
 ```bash
-git clone https://github.com/simple-agent-lab/EvolveX.git
-cd EvolveX
+git clone https://github.com/simple-agent-lab/RSIHub.git
+cd RSIHub
 uv sync --dev --locked
 uv run --frozen evolve --help
 ```
@@ -90,4 +90,4 @@ reports unmet preconditions as one checklist.
 - [Run preflight, smoke tests, and recovery commands](guides/operations.md)
 - [Configure meta-agent execution](guides/meta-agents.md)
 - [Use the trusted local Harbor backend](guides/local-environment.md)
-- [Understand recipes in the source repository](https://github.com/simple-agent-lab/EvolveX/tree/main/recipes)
+- [Understand recipes in the source repository](https://github.com/simple-agent-lab/RSIHub/tree/main/recipes)

--- a/docs/guides/local-environment.md
+++ b/docs/guides/local-environment.md
@@ -72,7 +72,7 @@ CODEX_FORCE_AUTH_JSON=1 uv run harbor run \
 
 Harbor reuses the Codex executable and login already available on the host. A
 successful Codex run still produces `agent/trajectory.json`, so it can be
-inspected with `harbor view <jobs-dir>`. Evolve's corresponding EvidenceCase
+inspected with `harbor view <jobs-dir>`. RSIHub's corresponding EvidenceCase
 keeps a workspace-relative path and SHA-256 digest for that ATIF rather than
 embedding another complete copy.
 

--- a/docs/guides/operations.md
+++ b/docs/guides/operations.md
@@ -1,4 +1,4 @@
-# Running EvolveX Reliably
+# Running RSIHub Reliably
 
 Use the lightweight checks for local skill and plugin iteration. Use the
 experiment checks before a real multi-generation benchmark run.
@@ -77,7 +77,7 @@ the shared content-bound Terminal-Bench subset and selected recipe image with:
 ```
 
 To download the complete upstream Harbor dataset without preparing the pinned
-EvolveX subset, export it directly:
+RSIHub subset, export it directly:
 
 ```bash
 uv run --frozen harbor download terminal-bench@2.0 \

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,13 +1,13 @@
-# EvolveX
+# RSIHub
 
 **Build agents that improve — and keep the evidence.**
 
-EvolveX is a file-based framework for running agent-evolution experiments
+RSIHub is a file-based framework for running agent-evolution experiments
 without rebuilding candidate snapshots, evaluation, lineage, and reporting for
 every method. It provides composable recipes inspired by A-Evolve, AHE, GEPA,
 Hill Climb, and HyperAgents.
 
-![EvolveX architecture](assets/architecture.svg)
+![RSIHub architecture](assets/architecture.svg)
 
 ## Start here
 
@@ -15,10 +15,10 @@ Hill Climb, and HyperAgents.
 
 | Step | Guide |
 | --- | --- |
-| 1. Install EvolveX and verify the local setup | [Getting started](getting-started.md) |
+| 1. Install RSIHub and verify the local setup | [Getting started](getting-started.md) |
 | 2. Configure credentials and the host runtime | [Environment Variables](reference/environment-variables.md) |
 | 3. Initialize a workspace and launch an experiment | [From recipe to experiment](guides/recipe-to-experiment.md) |
-| 4. Check, monitor, and recover a real run | [Running Evolve reliably](guides/operations.md) |
+| 4. Check, monitor, and recover a real run | [Running RSIHub reliably](guides/operations.md) |
 
 ### Build your own method
 
@@ -32,7 +32,7 @@ Hill Climb, and HyperAgents.
 For the framework model and vocabulary, see
 [Framework design](concepts/design.md) and [Terminology](reference/terminology.md).
 
-## What Evolve keeps fixed
+## What RSIHub keeps fixed
 
 Each experiment is a separate Git repository. Generation tags identify exact
 candidates, `archive.jsonl` records stamped outcomes, and the evaluator stays
@@ -48,7 +48,7 @@ See the [design guide](concepts/design.md) for the complete model and invariants
 
 ## Repository resources
 
-- [Supported recipes](https://github.com/simple-agent-lab/EvolveX/tree/main/recipes)
-- [Source architecture map](https://github.com/simple-agent-lab/EvolveX/blob/main/ARCHITECTURE.md)
-- [Contributing guide](https://github.com/simple-agent-lab/EvolveX/blob/main/CONTRIBUTING.md)
-- [GitHub repository](https://github.com/simple-agent-lab/EvolveX)
+- [Supported recipes](https://github.com/simple-agent-lab/RSIHub/tree/main/recipes)
+- [Source architecture map](https://github.com/simple-agent-lab/RSIHub/blob/main/ARCHITECTURE.md)
+- [Contributing guide](https://github.com/simple-agent-lab/RSIHub/blob/main/CONTRIBUTING.md)
+- [GitHub repository](https://github.com/simple-agent-lab/RSIHub)

--- a/docs/javascripts/repository-stats.js
+++ b/docs/javascripts/repository-stats.js
@@ -1,5 +1,5 @@
 (() => {
-  const selector = "[data-evolvex-repository-stats]"
+  const selector = "[data-rsihub-repository-stats]"
   const cacheLifetimeMs = 10 * 60 * 1000
   let currentStats
   let pendingStats
@@ -35,7 +35,7 @@
   }
 
   function cacheKey(source) {
-    return `evolvex-repository-stats:v1:${source.href}`
+    return `rsihub-repository-stats:v1:${source.href}`
   }
 
   function readCache(source) {
@@ -73,7 +73,7 @@
   }
 
   async function fetchFallbackStats(source) {
-    const response = await fetch(source.dataset.evolvexRepositoryStats, { cache: "no-cache" })
+    const response = await fetch(source.dataset.rsihubRepositoryStats, { cache: "no-cache" })
     if (!response.ok) throw new Error(`Repository statistics fallback returned ${response.status}`)
     return normalize(await response.json())
   }

--- a/docs/overrides/partials/source.html
+++ b/docs/overrides/partials/source.html
@@ -1,9 +1,9 @@
-{# Use EvolveX's live-API-first, same-origin-fallback repository statistics. #}
+{# Use RSIHub's live-API-first, same-origin-fallback repository statistics. #}
 <a
   href="{{ config.repo_url }}"
   title="{{ lang.t('source') }}"
   class="md-source"
-  data-evolvex-repository-stats="{{ 'assets/repository-stats.json' | url }}"
+  data-rsihub-repository-stats="{{ 'assets/repository-stats.json' | url }}"
 >
   <div class="md-source__icon md-icon">
     {% set icon = config.theme.icon.repo or "fontawesome/brands/git-alt" %}

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -77,7 +77,7 @@ Codex agents may use an explicit auth file instead of an API key:
 CODEX_AUTH_JSON_PATH=/absolute/path/to/auth.json
 ```
 
-The path must exist on the host. EvolveX does not implicitly search
+The path must exist on the host. RSIHub does not implicitly search
 `~/.codex/auth.json` for an experiment run. Non-Codex agents do not accept a
 Codex auth file.
 
@@ -187,7 +187,7 @@ cause HTTP clients to fail before a model request is made.
 Do not copy another machine's proxy or `NO_PROXY` values. They are
 host/network-specific.
 
-## Variables managed by EvolveX
+## Variables managed by RSIHub
 
 Variables such as the following are generated for an individual operator or
 evaluation attempt and should not normally be set by users:

--- a/docs/reference/operators.md
+++ b/docs/reference/operators.md
@@ -1,6 +1,6 @@
 # Operator overview
 
-Operators are the composable stages of an EvolveX generation. Their names in
+Operators are the composable stages of an RSIHub generation. Their names in
 this reference are identical to the keys used under `operators:` in
 `evolve.yaml`.
 

--- a/docs/reference/terminology.md
+++ b/docs/reference/terminology.md
@@ -1,4 +1,4 @@
-# EvolveX
+# RSIHub
 
 Evidence-driven evolution of agents, prompts, and agent harnesses. Each
 experiment is one Git repository (a workspace) in which a frozen evaluator

--- a/docs/rsihub-mark.svg
+++ b/docs/rsihub-mark.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 128 128" role="img" aria-labelledby="mark-title mark-description">
-  <title id="mark-title">Evolve selected lineage mark</title>
+  <title id="mark-title">RSIHub selected lineage mark</title>
   <desc id="mark-description">A selected candidate path rises past explored side branches to a verified generation.</desc>
   <rect x="4" y="4" width="120" height="120" rx="28" fill="#10372e"/>
   <path d="M 48 82 L 68 103 M 66 61 L 45 38 M 86 42 L 105 62" fill="none" stroke="#b5d3c7" stroke-width="4" stroke-linecap="round" data-state="explored"/>

--- a/evals/README.md
+++ b/evals/README.md
@@ -2,7 +2,7 @@
 
 `evals/` contains reviewable evaluation definitions and recorded result
 snapshots for project-owned agents and skills. It is a research and quality
-evaluation area, not the evaluator runtime used by a generated EvolveX
+evaluation area, not the evaluator runtime used by a generated RSIHub
 workspace.
 
 ## Current layout

--- a/evals/skills/make-paper-poster/prepare_dataset.py
+++ b/evals/skills/make-paper-poster/prepare_dataset.py
@@ -62,7 +62,7 @@ def load_cases() -> list[dict[str, object]]:
 def download(url: str, destination: Path) -> str:
     if not destination.is_file():
         pending = destination.with_suffix(".pending")
-        request = urllib.request.Request(url, headers={"User-Agent": "evolvex-paper-poster/1"})
+        request = urllib.request.Request(url, headers={"User-Agent": "rsihub-paper-poster/1"})
         with urllib.request.urlopen(request, timeout=120) as response, pending.open("wb") as stream:
             shutil.copyfileobj(response, stream)
         pending.replace(destination)

--- a/evals/skills/make-paper-poster/recipe/evaluator/prepare_poster_runtime.py
+++ b/evals/skills/make-paper-poster/recipe/evaluator/prepare_poster_runtime.py
@@ -98,7 +98,7 @@ def renderer_asset(system: str | None = None, machine: str | None = None) -> Ass
 
 
 def download(asset: Asset, destination: Path) -> None:
-    request = urllib.request.Request(asset.url, headers={"User-Agent": "evolvex-paper-poster/1"})
+    request = urllib.request.Request(asset.url, headers={"User-Agent": "rsihub-paper-poster/1"})
     with urllib.request.urlopen(request, timeout=120) as response, destination.open("wb") as output:
         shutil.copyfileobj(response, output)
     actual = sha256_file(destination)

--- a/library/PROTOCOL.md
+++ b/library/PROTOCOL.md
@@ -1,4 +1,4 @@
-# EvolveX Operator Protocol
+# RSIHub Operator Protocol
 
 This document describes protocol version `1` for workspace operators. The
 mechanism launches operator files as subprocesses and consumes files from the

--- a/library/meta_agent/runners/harbor.py
+++ b/library/meta_agent/runners/harbor.py
@@ -245,8 +245,8 @@ def _nonignored_manifest_changes(
 
 def _initialize_sanitized_git(workspace: Path) -> None:
     git(workspace, "init", "--quiet")
-    git(workspace, "config", "user.name", "EvolveX Meta-Agent")
-    git(workspace, "config", "user.email", "meta-agent@evolvex.invalid")
+    git(workspace, "config", "user.name", "RSIHub Meta-Agent")
+    git(workspace, "config", "user.email", "meta-agent@rsihub.invalid")
     # This repository is copied into the Harbor task immediately after the
     # baseline commit.  Git may otherwise detach automatic maintenance on
     # platforms such as macOS, racing that copy as maintenance.lock appears

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,15 +1,15 @@
-site_name: EvolveX
+site_name: RSIHub
 site_description: Build agents that improve — and keep the evidence.
-site_url: https://simple-agent-lab.github.io/EvolveX/
-repo_url: https://github.com/simple-agent-lab/EvolveX
-repo_name: simple-agent-lab/EvolveX
+site_url: https://simple-agent-lab.github.io/RSIHub/
+repo_url: https://github.com/simple-agent-lab/RSIHub
+repo_name: simple-agent-lab/RSIHub
 edit_uri: edit/main/docs/
 
 theme:
   name: material
   custom_dir: docs/overrides
-  logo: evolve-mark.svg
-  favicon: evolve-mark.svg
+  logo: rsihub-mark.svg
+  favicon: rsihub-mark.svg
   language: en
   features:
     - navigation.sections
@@ -42,7 +42,7 @@ nav:
   - Guides:
       - Creating a custom recipe: guides/custom-recipes.md
       - From recipe to experiment: guides/recipe-to-experiment.md
-      - Running Evolve reliably: guides/operations.md
+      - Running RSIHub reliably: guides/operations.md
       - Meta-agent execution: guides/meta-agents.md
       - Local Harbor environment: guides/local-environment.md
   - Reference:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "evolvex"
+name = "rsihub"
 version = "0.1.0"
 description = "File-based framework for evolving coding agents."
 readme = "README.md"
@@ -26,10 +26,10 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/simple-agent-lab/EvolveX"
-Documentation = "https://simple-agent-lab.github.io/EvolveX/"
-Repository = "https://github.com/simple-agent-lab/EvolveX"
-Issues = "https://github.com/simple-agent-lab/EvolveX/issues"
+Homepage = "https://github.com/simple-agent-lab/RSIHub"
+Documentation = "https://simple-agent-lab.github.io/RSIHub/"
+Repository = "https://github.com/simple-agent-lab/RSIHub"
+Issues = "https://github.com/simple-agent-lab/RSIHub/issues"
 
 [project.scripts]
 evolve = "evolve.cli:main"

--- a/recipes/aevolve/README.md
+++ b/recipes/aevolve/README.md
@@ -1,7 +1,7 @@
 # A-Evolve
 
 This recipe maps the default `AEvolveEngine` workspace-mutation pass from
-`a-evolve` onto EvolveX's existing operator protocol.
+`a-evolve` onto RSIHub's existing operator protocol.
 
 Each generation uses a fixed train split as the observation batch and converts
 Harbor's complete ordered events into A-Evolve's `trajectory_only` evidence:
@@ -17,7 +17,7 @@ successful evolution pass, matching `AEvolveEngine`.
 
 The mapping is:
 
-| A-Evolve responsibility | EvolveX implementation |
+| A-Evolve responsibility | RSIHub implementation |
 | --- | --- |
 | solve tasks and retain observations | Harbor rollout |
 | behavior-only observation view | `trace_analyzer: trajectory_only` |

--- a/recipes/ahe/README.md
+++ b/recipes/ahe/README.md
@@ -43,7 +43,7 @@ Candidate execution uses Harbor's native task timeouts
 (`agent_timeout_multiplier: 1`).
 
 ```bash
-cd /path/to/EvolveX
+cd /path/to/RSIHub
 evolve init /path/to/ahe-run --recipe ahe --tasks 3
 cd /path/to/ahe-run
 ./evolve preflight .

--- a/recipes/gepa_local/README.md
+++ b/recipes/gepa_local/README.md
@@ -18,7 +18,7 @@ first installed CLI in this order: Codex, Claude Code, Gemini CLI, OpenCode.
 Set `EVOLVE_LOCAL_AGENT=claude-code` (or another supported name) to override the
 choice. Each CLI is executed through Harbor's own installed-agent adapter, so
 the trial retains a validated ATIF `agent/trajectory.json` instead of an
-Evolve-specific trace format. Codex reuses `~/.codex/auth.json` when present;
+RSIHub-specific trace format. Codex reuses `~/.codex/auth.json` when present;
 credentials are copied into the per-trial local root rather than written into
 the workspace or run artifacts.
 

--- a/scaffolds/workspace/AGENTS.md
+++ b/scaffolds/workspace/AGENTS.md
@@ -1,4 +1,4 @@
-# EvolveX Workspace
+# RSIHub Workspace
 
 This repository is a self-driving evolvable workspace. The operating manual
 is **`skills/evolve-agent/SKILL.md`** — read it first. It works for any

--- a/scaffolds/workspace/README.md
+++ b/scaffolds/workspace/README.md
@@ -1,4 +1,4 @@
-# This is an EvolveX workspace
+# This is an RSIHub workspace
 
 This directory is an independent Git repository. Each candidate generation is
 a commit tagged `gen/<id>`; `archive.jsonl` records the append-only lineage.
@@ -22,8 +22,8 @@ archive.jsonl                 append-only lineage record
 evolve                        workspace console
 evolve.yaml                   rendered recipe configuration
 library/                      recipe-relevant operator variants
-LICENSE.evolvex               license for the vendored framework and operator library
-NOTICE.evolvex                framework and third-party attribution notices
+LICENSE.rsihub                license for the vendored framework and operator library
+NOTICE.rsihub                 framework and third-party attribution notices
 operators/                    active operator scripts, supporting Markdown, and index
 program.md                    loop orchestration guidance
 pyproject.toml, uv.lock       locked workspace runtime
@@ -59,7 +59,7 @@ directly: workspace evaluation first prepares its certified private runtime
 inputs.
 
 The vendored framework runtime and operator library are provided under
-Apache-2.0; see `LICENSE.evolvex` and `NOTICE.evolvex`.
+Apache-2.0; see `LICENSE.rsihub` and `NOTICE.rsihub`.
 The target under `target/` retains its own upstream licensing terms.
 
 ## Rules

--- a/scripts/fetch_repository_stats.py
+++ b/scripts/fetch_repository_stats.py
@@ -12,7 +12,7 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
-DEFAULT_REPOSITORY = "simple-agent-lab/EvolveX"
+DEFAULT_REPOSITORY = "simple-agent-lab/RSIHub"
 DEFAULT_OUTPUT = Path("docs/assets/repository-stats.json")
 
 
@@ -28,7 +28,7 @@ def fetch_repository_stats(repository: str, token: str | None) -> dict[str, Any]
         f"https://api.github.com/repos/{repository}",
         headers={
             "Accept": "application/vnd.github+json",
-            "User-Agent": "EvolveX-docs-build",
+            "User-Agent": "RSIHub-docs-build",
             "X-GitHub-Api-Version": "2022-11-28",
             **({"Authorization": f"Bearer {token}"} if token else {}),
         },
@@ -69,7 +69,7 @@ def has_usable_fallback(output: Path) -> bool:
 
 def main() -> int:
     repository = os.environ.get("GITHUB_REPOSITORY", DEFAULT_REPOSITORY)
-    output = Path(os.environ.get("EVOLVEX_REPOSITORY_STATS_PATH", DEFAULT_OUTPUT))
+    output = Path(os.environ.get("RSIHUB_REPOSITORY_STATS_PATH", DEFAULT_OUTPUT))
     try:
         stats = fetch_repository_stats(repository, os.environ.get("GITHUB_TOKEN"))
         write_repository_stats(output, stats)

--- a/seeds/codex/.agents/plugins/marketplace.json
+++ b/seeds/codex/.agents/plugins/marketplace.json
@@ -1,7 +1,7 @@
 {
   "name": "evolve-target",
   "interface": {
-    "displayName": "Evolve Target"
+    "displayName": "RSIHub Target"
   },
   "plugins": [
     {

--- a/seeds/codex/README.md
+++ b/seeds/codex/README.md
@@ -1,7 +1,7 @@
 # Built-in Codex Target
 
 This target wraps Harbor's installed Codex agent while keeping the behavior
-surface under `target/**` so EvolveX can mutate it.
+surface under `target/**` so RSIHub can mutate it.
 
 - `agent.py` injects the candidate-owned prompt, skills, and Codex flags.
 - `prompt.md` is the task prompt template and must retain `{{ instruction }}`.

--- a/seeds/codex/agent.py
+++ b/seeds/codex/agent.py
@@ -129,7 +129,7 @@ class HarborAgent(Codex):
             configs = [
                 'model_provider="evolve_http"',
                 'forced_login_method="api"',
-                'model_providers.evolve_http.name="Evolve HTTP Responses"',
+                'model_providers.evolve_http.name="RSIHub HTTP Responses"',
                 f'model_providers.evolve_http.base_url="{base_url}"',
                 'model_providers.evolve_http.env_key="OPENAI_API_KEY"',
                 'model_providers.evolve_http.wire_api="responses"',

--- a/seeds/codex/plugins/evolve-target/.codex-plugin/plugin.json
+++ b/seeds/codex/plugins/evolve-target/.codex-plugin/plugin.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "Candidate-owned Codex behaviors evolved against coding benchmarks.",
   "author": {
-    "name": "Evolve Framework"
+    "name": "RSIHub Framework"
   },
   "license": "Apache-2.0",
   "keywords": [
@@ -11,10 +11,10 @@
     "hooks"
   ],
   "interface": {
-    "displayName": "Evolve Target",
+    "displayName": "RSIHub Target",
     "shortDescription": "Evolvable Codex benchmark behavior",
-    "longDescription": "Candidate-owned lifecycle hooks and context evaluated by Evolve Framework.",
-    "developerName": "Evolve Framework",
+    "longDescription": "Candidate-owned lifecycle hooks and context evaluated by RSIHub Framework.",
+    "developerName": "RSIHub Framework",
     "category": "Developer Tools",
     "capabilities": [
       "Hooks"

--- a/skills/evolve-agent/agents/openai.yaml
+++ b/skills/evolve-agent/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
-  display_name: "EvolveX Agent"
+  display_name: "RSIHub Agent"
   short_description: "Evolve agents with reusable operators and evidence"
   default_prompt: "Use $evolve-agent to operate this workspace and improve the agent through an evidence-backed generation."

--- a/src/evolve/__init__.py
+++ b/src/evolve/__init__.py
@@ -1,3 +1,3 @@
-"""EvolveX mechanism CLI."""
+"""RSIHub mechanism CLI."""
 
 __version__ = "0.1.0"

--- a/src/evolve/cli.py
+++ b/src/evolve/cli.py
@@ -29,7 +29,7 @@ from .run_summary import assert_run_success, write_run_summary
 from .surface import check_paths, surface_patterns
 from .workspace import InitOptions, init_workspace
 
-app = typer.Typer(add_completion=False, no_args_is_help=True, help="EvolveX mechanism CLI")
+app = typer.Typer(add_completion=False, no_args_is_help=True, help="RSIHub mechanism CLI")
 DEFAULT_WORKSPACE = Path("~/.evolve-workspace")
 
 
@@ -94,7 +94,7 @@ def init(
     dataset: str | None = typer.Option(None, help="local Harbor task directory to split and freeze"),
     tasks: int | None = typer.Option(None, "--tasks", min=1, help="limit evaluator tasks per round"),
 ) -> None:
-    """Scaffold a new EvolveX workspace."""
+    """Scaffold a new RSIHub workspace."""
     workspace = (workspace or DEFAULT_WORKSPACE).expanduser()
     if recipe is not None and recipe_path is not None:
         raise typer.BadParameter(
@@ -117,7 +117,7 @@ def init(
             tasks_per_round=tasks,
         )
     )
-    print(f"Initialized EvolveX workspace at {workspace}")
+    print(f"Initialized RSIHub workspace at {workspace}")
 
 
 @app.command()

--- a/src/evolve/doctor.py
+++ b/src/evolve/doctor.py
@@ -189,7 +189,7 @@ def run_doctor(
     config_path = root / "evolve.yaml"
     config = load_config(config_path) if config_path.is_file() else {}
     if profile == "experiment" and not config:
-        raise ValueError("experiment doctor requires an initialized EvolveX workspace")
+        raise ValueError("experiment doctor requires an initialized RSIHub workspace")
 
     report_dir = root / "runs" / "doctor"
     report_dir.mkdir(parents=True, exist_ok=True)

--- a/src/evolve/execution_runtime/__init__.py
+++ b/src/evolve/execution_runtime/__init__.py
@@ -1,4 +1,4 @@
-"""Resolve the host execution backend used by EvolveX and Harbor."""
+"""Resolve the host execution backend used by RSIHub and Harbor."""
 
 from .config import execution_runtime_config
 from .environment import prepare_execution_environment

--- a/src/evolve/execution_runtime/probes.py
+++ b/src/evolve/execution_runtime/probes.py
@@ -208,9 +208,7 @@ def probe_execution_runtime(
                 else (mounted.stderr or mounted.stdout or "bind mount marker did not return to the host").strip()[
                     -1000:
                 ],
-                None
-                if mount_verified
-                else "use a path shared with the Docker daemon or run EvolveX on the daemon host",
+                None if mount_verified else "use a path shared with the Docker daemon or run RSIHub on the daemon host",
             )
         )
 

--- a/src/evolve/experiment_smoke.py
+++ b/src/evolve/experiment_smoke.py
@@ -75,8 +75,8 @@ def _rewrite_eval_env(path: Path) -> None:
 def _prepare_smoke_workspace(source: Path, destination: Path, task: str, _digest: str) -> None:
     # The destination is inside source/runs; pack transport avoids macOS local-clone copy races.
     git(source, "clone", "--quiet", "--no-local", str(source), str(destination))
-    git(destination, "config", "user.name", "EvolveX Experiment Smoke")
-    git(destination, "config", "user.email", "smoke@evolvex.invalid")
+    git(destination, "config", "user.name", "RSIHub Experiment Smoke")
+    git(destination, "config", "user.email", "smoke@rsihub.invalid")
     for tag in git_stdout(destination, "tag", "--list").splitlines():
         git(destination, "tag", "--delete", tag, check=False)
     for path in (destination / "archive.jsonl", destination / ".evolve-eval-receipts.jsonl"):

--- a/src/evolve/host_runtime.py
+++ b/src/evolve/host_runtime.py
@@ -18,7 +18,7 @@ def clean_python_env(source: Mapping[str, str] | None = None) -> dict[str, str]:
 
 
 def uv_executable(env: Mapping[str, str] | None = None) -> str:
-    """Resolve uv from the explicit EvolveX override or the supplied PATH."""
+    """Resolve uv from the explicit RSIHub override or the supplied PATH."""
     values = os.environ if env is None else env
     configured = values.get("EVOLVE_UV_BINARY")
     candidate = configured or shutil.which("uv", path=values.get("PATH"))

--- a/src/evolve/integrations/__init__.py
+++ b/src/evolve/integrations/__init__.py
@@ -1,1 +1,1 @@
-"""External runtime integrations owned by EvolveX."""
+"""External runtime integrations owned by RSIHub."""

--- a/src/evolve/integrations/harbor/__init__.py
+++ b/src/evolve/integrations/harbor/__init__.py
@@ -1,1 +1,1 @@
-"""Harbor agent integrations shipped with EvolveX."""
+"""Harbor agent integrations shipped with RSIHub."""

--- a/src/evolve/integrations/harbor/_agent_roles.py
+++ b/src/evolve/integrations/harbor/_agent_roles.py
@@ -1,4 +1,4 @@
-"""Exact identities for Evolve-owned MiniSWE Harbor adapter roles."""
+"""Exact identities for RSIHub-owned MiniSWE Harbor adapter roles."""
 
 from __future__ import annotations
 

--- a/src/evolve/integrations/harbor/codex_candidate.py
+++ b/src/evolve/integrations/harbor/codex_candidate.py
@@ -32,7 +32,7 @@ class ResponsesCodexAgent(Codex):
         configs = [
             'model_provider="evolve_http"',
             'forced_login_method="api"',
-            'model_providers.evolve_http.name="EvolveX HTTP Responses"',
+            'model_providers.evolve_http.name="RSIHub HTTP Responses"',
             f'model_providers.evolve_http.base_url="{base_url}"',
             'model_providers.evolve_http.env_key="OPENAI_API_KEY"',
             'model_providers.evolve_http.wire_api="responses"',

--- a/src/evolve/integrations/harbor/local_auto_agent.py
+++ b/src/evolve/integrations/harbor/local_auto_agent.py
@@ -3,7 +3,7 @@
 The adapter is intentionally limited to ``evolve.harbor_local:LocalEnvironment``.
 It preserves Harbor's installed-agent implementations as the authority for CLI
 invocation, authentication, usage accounting, and ATIF conversion while adding a
-single backend-agnostic entry point for local Evolve runs.
+single backend-agnostic entry point for local RSIHub runs.
 """
 
 from __future__ import annotations

--- a/src/evolve/meta_agent_budget.py
+++ b/src/evolve/meta_agent_budget.py
@@ -4,7 +4,7 @@ Harbor 0.18 bounds environment image preparation and verifier execution at
 600 seconds each, and agent setup at 360 seconds.  Agent execution is bounded
 separately by the configured per-attempt timeout.  Harbor does not put one
 aggregate deadline around artifact/log collection or environment teardown, so
-EvolveX assigns each of those lifecycle phases the same conservative 600-second
+RSIHub assigns each of those lifecycle phases the same conservative 600-second
 allowance as Harbor's standard bounded phases.
 
 The Harbor process budget is:
@@ -42,7 +42,7 @@ HARBOR_ENVIRONMENT_START_S = 600.0
 HARBOR_AGENT_SETUP_S = 360.0
 HARBOR_VERIFIER_S = 600.0
 
-# Explicit EvolveX allowances for Harbor phases without their own aggregate cap.
+# Explicit RSIHub allowances for Harbor phases without their own aggregate cap.
 HARBOR_ARTIFACT_LOG_COLLECTION_S = 600.0
 HARBOR_TEARDOWN_FINALIZATION_S = 600.0
 HARBOR_TASK_COMPILATION_S = 600.0

--- a/src/evolve/workspace.py
+++ b/src/evolve/workspace.py
@@ -273,8 +273,8 @@ def _write_files(
         "README.md": _workspace_scaffold("README.md"),
         "AGENTS.md": _workspace_scaffold("AGENTS.md"),
         "program.md": _workspace_scaffold("program.md"),
-        "LICENSE.evolvex": _framework_legal_text("LICENSE"),
-        "NOTICE.evolvex": _framework_legal_text("NOTICE"),
+        "LICENSE.rsihub": _framework_legal_text("LICENSE"),
+        "NOTICE.rsihub": _framework_legal_text("NOTICE"),
         ".gitignore": _workspace_scaffold(".gitignore"),
         ".evolve-protocol-version": "1\n",
         "operators/engines/local.sh": _shell_script("operator local engine"),
@@ -859,8 +859,8 @@ def _remove_generated_target_metadata(target: Path) -> None:
 
 def _init_git(workspace: Path) -> None:
     _git(workspace, "init")
-    _git(workspace, "config", "user.name", "EvolveX Mechanism")
-    _git(workspace, "config", "user.email", "evolvex@example.invalid")
+    _git(workspace, "config", "user.name", "RSIHub Mechanism")
+    _git(workspace, "config", "user.email", "rsihub@example.invalid")
     _git(workspace, "add", ".")
     # A vendored seed is an exact experiment input. Its own ignore rules must
     # not silently remove copied files (for example an upstream-ignored

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -254,7 +254,7 @@ def write_locked_miniswe_seed(path: Path) -> Path:
         text=True,
         capture_output=True,
         check=False,
-        env={**os.environ, "UV_CACHE_DIR": os.environ.get("UV_CACHE_DIR", "/tmp/evolvex-test-uv")},
+        env={**os.environ, "UV_CACHE_DIR": os.environ.get("UV_CACHE_DIR", "/tmp/rsihub-test-uv")},
     )
     assert result.returncode == 0, result.stderr
     return path

--- a/tests/fixtures/seeds/dummy/agent.py
+++ b/tests/fixtures/seeds/dummy/agent.py
@@ -1,4 +1,4 @@
-"""Tiny seed target used by a fresh EvolveX workspace."""
+"""Tiny seed target used by a fresh RSIHub workspace."""
 
 
 def answer(prompt: str) -> str:

--- a/tests/test_docs_repository_stats.py
+++ b/tests/test_docs_repository_stats.py
@@ -22,12 +22,12 @@ def test_repository_stats_fallback_files_are_wired_into_mkdocs() -> None:
     assert "javascripts/repository-stats.js" in config["extra_javascript"]
 
     source = (ROOT / "docs" / "overrides" / "partials" / "source.html").read_text()
-    assert "data-evolvex-repository-stats" in source
+    assert "data-rsihub-repository-stats" in source
     assert 'data-md-component="source"' not in source
 
     javascript = (ROOT / "docs" / "javascripts" / "repository-stats.js").read_text()
     assert "https://api.github.com/repos/" in javascript
-    assert "evolvexRepositoryStats" in javascript
+    assert "rsihubRepositoryStats" in javascript
     assert "md-source__fact--${kind}" in javascript
 
 
@@ -50,7 +50,7 @@ def test_docs_workflow_refreshes_repository_stats_twice_daily() -> None:
 def test_repository_stats_json_has_valid_counts() -> None:
     payload = json.loads((ROOT / "docs" / "assets" / "repository-stats.json").read_text())
     assert payload["schema_version"] == 1
-    assert payload["repository"] == "simple-agent-lab/EvolveX"
+    assert payload["repository"] == "simple-agent-lab/RSIHub"
     assert isinstance(payload["stars"], int) and payload["stars"] >= 0
     assert isinstance(payload["forks"], int) and payload["forks"] >= 0
 

--- a/tests/test_m0_init.py
+++ b/tests/test_m0_init.py
@@ -140,7 +140,7 @@ def test_init_defaults_to_home_workspace(monkeypatch, tmp_path: Path) -> None:
     assert result.exit_code == 0, result.output
     assert len(captured) == 1
     assert captured[0].workspace == tmp_path / ".evolve-workspace"
-    assert f"Initialized EvolveX workspace at {tmp_path / '.evolve-workspace'}" in result.output
+    assert f"Initialized RSIHub workspace at {tmp_path / '.evolve-workspace'}" in result.output
 
 
 def test_init_explicit_workspace_still_wins(monkeypatch, tmp_path: Path) -> None:
@@ -513,8 +513,8 @@ def test_init_scaffolds_hill_climb_workspace(tmp_path: Path) -> None:
         ".evolve/evolve/harbor_local.py",
         "AGENTS.md",
         "program.md",
-        "LICENSE.evolvex",
-        "NOTICE.evolvex",
+        "LICENSE.rsihub",
+        "NOTICE.rsihub",
         "operators/select.py",
         "operators/rollout.py",
         "operators/meta_agent.py",
@@ -568,8 +568,8 @@ def test_init_scaffolds_hill_climb_workspace(tmp_path: Path) -> None:
     assert (workspace / ".python-version").read_text() == "3.12\n"
     assert "harbor==0.18.0" in (workspace / "pyproject.toml").read_text()
     assert 'packages = [".evolve/evolve", "library"]' in (workspace / "pyproject.toml").read_text()
-    assert "Apache License" in (workspace / "LICENSE.evolvex").read_text()
-    assert "GEPA" in (workspace / "NOTICE.evolvex").read_text()
+    assert "Apache License" in (workspace / "LICENSE.rsihub").read_text()
+    assert "GEPA" in (workspace / "NOTICE.rsihub").read_text()
 
     config = (workspace / "evolve.yaml").read_text()
     assert "children_per_gen: 1" in config

--- a/tests/test_public_repository.py
+++ b/tests/test_public_repository.py
@@ -1,5 +1,6 @@
 import re
 import shlex
+import subprocess
 import tomllib
 import xml.etree.ElementTree as ET
 from pathlib import Path
@@ -11,6 +12,46 @@ from evolve import __version__
 ROOT = Path(__file__).resolve().parents[1]
 RELATIVE_LINK = re.compile(r"\[[^\]]+\]\((?!https?://|mailto:|#)([^)#]+)")
 SVG_NS = {"svg": "http://www.w3.org/2000/svg"}
+
+
+def test_tracked_files_use_only_current_project_identity() -> None:
+    retired = ("evolve" + "x", "simple-" + "evolve-agent")
+    standalone = "Evo" + "lve"
+    allowed_standalone_uses = {
+        "README.md": (f"What Can {standalone}",),
+        "evals/skills/make-paper-poster/recipe/evaluator/doctor_smoke.py": (f">{standalone}<",),
+        "library/PROTOCOL.md": (f"{standalone} freely",),
+        "skills/evolve-agent/agents/openai.yaml": (f"{standalone} agents",),
+    }
+    result = subprocess.run(
+        ["git", "ls-files", "-z"],
+        cwd=ROOT,
+        check=True,
+        capture_output=True,
+    )
+    paths = [Path(raw.decode()) for raw in result.stdout.split(b"\0") if raw]
+    stale: list[str] = []
+    for relative in paths:
+        folded_path = relative.as_posix().casefold()
+        for identity in retired:
+            if identity in folded_path:
+                stale.append(f"path:{relative}")
+        try:
+            text = (ROOT / relative).read_text()
+        except UnicodeDecodeError:
+            continue
+        folded_text = text.casefold()
+        for identity in retired:
+            if identity in folded_text:
+                stale.append(f"text:{relative}")
+        for line_number, line in enumerate(text.splitlines(), start=1):
+            without_method_name = line.replace(f"A-{standalone}", "")
+            if not re.search(rf"\b{standalone}\b", without_method_name):
+                continue
+            allowed = allowed_standalone_uses.get(relative.as_posix(), ())
+            if not any(phrase in line for phrase in allowed):
+                stale.append(f"semantic:{relative}:{line_number}")
+    assert sorted(set(stale)) == []
 
 
 def _relative_luminance(color: str) -> float:
@@ -34,7 +75,7 @@ def test_architecture_visual_uses_identity_palette() -> None:
 
 
 def test_readme_visual_assets_have_accessible_svg_metadata() -> None:
-    for relative in ("docs/evolve-mark.svg", "docs/evolve-lineage.svg"):
+    for relative in ("docs/rsihub-mark.svg", "docs/evolve-lineage.svg"):
         root = ET.parse(ROOT / relative).getroot()
         assert root.attrib["role"] == "img"
         assert root.attrib["viewBox"]
@@ -46,7 +87,7 @@ def test_readme_visual_assets_have_accessible_svg_metadata() -> None:
 
 def test_selected_and_explored_graphics_have_three_to_one_contrast() -> None:
     expected_state_counts = {
-        "docs/evolve-mark.svg": {"selected": 5, "explored": 1},
+        "docs/rsihub-mark.svg": {"selected": 5, "explored": 1},
         "docs/evolve-lineage.svg": {"selected": 5, "explored": 4},
     }
     for relative, expected_counts in expected_state_counts.items():
@@ -125,10 +166,17 @@ def test_mkdocs_covers_custom_recipe_operator_and_experiment_workflows() -> None
 
 def test_license_metadata_and_notice_are_consistent() -> None:
     project = tomllib.loads((ROOT / "pyproject.toml").read_text())["project"]
+    assert project["name"] == "rsihub"
+    assert project["urls"] == {
+        "Homepage": "https://github.com/simple-agent-lab/RSIHub",
+        "Documentation": "https://simple-agent-lab.github.io/RSIHub/",
+        "Repository": "https://github.com/simple-agent-lab/RSIHub",
+        "Issues": "https://github.com/simple-agent-lab/RSIHub/issues",
+    }
     assert project["version"] == __version__
     assert project["license"] == "Apache-2.0"
     assert "Apache License" in (ROOT / "LICENSE").read_text()
-    assert (ROOT / "NOTICE").read_text().startswith("EvolveX\n")
+    assert (ROOT / "NOTICE").read_text().startswith("RSIHub\n")
 
 
 def test_required_public_repository_files_exist() -> None:

--- a/tests/test_release_artifact.py
+++ b/tests/test_release_artifact.py
@@ -54,12 +54,12 @@ def test_release_wheel_has_one_resource_owner_and_complete_metadata() -> None:
         metadata_path = next(name for name in names if name.endswith(".dist-info/METADATA"))
         metadata = Parser().parsestr(archive.read(metadata_path).decode())
 
-    assert metadata["Name"] == "evolvex"
+    assert metadata["Name"] == "rsihub"
     assert metadata["Description-Content-Type"] == "text/markdown"
-    assert "EvolveX" in metadata.get_payload()
+    assert "RSIHub" in metadata.get_payload()
     project_urls = metadata.get_all("Project-URL") or []
-    assert any(value.startswith("Repository, https://github.com/") for value in project_urls)
-    assert any(value.startswith("Issues, https://github.com/") for value in project_urls)
+    assert "Repository, https://github.com/simple-agent-lab/RSIHub" in project_urls
+    assert "Issues, https://github.com/simple-agent-lab/RSIHub/issues" in project_urls
 
 
 def test_release_sdist_contains_legal_and_build_files() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -446,7 +446,7 @@ wheels = [
 ]
 
 [[package]]
-name = "evolvex"
+name = "rsihub"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [


### PR DESCRIPTION
## Summary

- rename the public project and Python distribution identity to RSIHub / `rsihub`
- update repository metadata, URLs, docs, legal notices, CI identities, generated-workspace branding, visual assets, seed/plugin display labels, and repository-statistics integration
- preserve the established `evolve` CLI, Python package, configuration, environment-variable, workspace, provider, plugin-path, and skill interfaces
- add a tracked-file regression guard for retired literal and semantic project identities

## Why

The project is adopting RSIHub as its sole public identity. The migration keeps existing technical interfaces stable so commands, integrations, and generated workspaces do not break solely because of the branding change.

## Impact

The published distribution becomes `rsihub`, project links target `simple-agent-lab/RSIHub`, and generated legal files become `LICENSE.rsihub` and `NOTICE.rsihub`. The external GitHub repository rename remains an owner-side operation; this PR updates tracked links to the intended destination.

## Validation

- `uv lock --check`
- `uv run --group docs --frozen mkdocs build --strict`
- `uv run --frozen pytest -q` — 954 passed, 3 skipped
- `uv run --frozen ruff check .`
- `uv run --frozen ruff format --check .`
- `uv run --frozen ty check`
- focused identity, coherence, Codex seed, and repository-statistics tests
- clean diff against current remote `main`
- final independent review: ready to merge

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Rebranded project documentation, guides, support resources, and contribution materials from EvolveX to RSIHub.
  * Updated repository links, badges, setup instructions, security contacts, and project metadata.

* **New Features**
  * Workspace initialization now uses RSIHub branding, including updated license and notice filenames.

* **Bug Fixes**
  * Updated CLI messages, generated configuration, repository statistics, and release metadata to consistently use RSIHub branding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->