### PR TITLE
Align public URLs with canonical RSIHub domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,13 @@
   <a href="https://www.python.org/">
     <img alt="Python 3.12+" src="https://img.shields.io/badge/Python-3.12%2B-3776AB?logo=python&amp;logoColor=white">
   </a>
-  <a href="https://simple-agent-lab.github.io/RSIHub/">
+  <a href="https://simpleagentlab.com/RSIHub/">
     <img alt="RSIHub documentation" src="https://img.shields.io/badge/Documentation-RSIHub-0F766E?logo=materialformkdocs&amp;logoColor=white">
   </a>
 </p>
 
 <p align="center">
+  <a href="https://simpleagentlab.com/rsihub/">RSIHub Website</a> ·
   <a href="#what-rsihub-does">What RSIHub Does</a> ·
   <a href="#how-rsihub-works">How It Works</a> ·
   <a href="#what-can-evolve">What Can Evolve</a> ·
@@ -309,7 +310,7 @@ composable strategies for different agent-evolution scenarios.
 
 Working on or with RSIHub from a coding agent? Start here:
 
-- [`llms.txt`](https://simple-agent-lab.github.io/RSIHub/llms.txt) — a
+- [`llms.txt`](https://simpleagentlab.com/RSIHub/llms.txt) — a
   machine-friendly index of the documentation following the
   [llms.txt convention](https://llmstxt.org/), with links to raw Markdown
   sources.
@@ -326,7 +327,7 @@ Working on or with RSIHub from a coding agent? Start here:
 
 | Document | Purpose |
 | --- | --- |
-| [Documentation site](https://simple-agent-lab.github.io/RSIHub/) | Installation, operation, concepts, guides, and reference. |
+| [Documentation site](https://simpleagentlab.com/RSIHub/) | Installation, operation, concepts, guides, and reference. |
 | [Quick start](QUICKSTART.md) | Recipe launcher setup and configuration. |
 | [Design](docs/concepts/design.md) | System model, ownership boundaries, and invariants. |
 | [Architecture](ARCHITECTURE.md) | Enforced source-module map and line budgets. |

--- a/docs/index.md
+++ b/docs/index.md
@@ -56,7 +56,7 @@ See the [design guide](concepts/design.md) for the complete model and invariants
 ## For AI agents
 
 Reading this site from an LLM or coding agent? Fetch
-[`llms.txt`](https://simple-agent-lab.github.io/RSIHub/llms.txt) — a
+[`llms.txt`](https://simpleagentlab.com/RSIHub/llms.txt) — a
 machine-friendly index of this documentation with links to the raw Markdown
 sources — and
 [`AGENTS.md`](https://github.com/simple-agent-lab/RSIHub/blob/main/AGENTS.md)

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -26,7 +26,7 @@ Key facts for working with RSIHub:
 
 All documentation is authored as Markdown. The links below point to the raw
 Markdown sources, which are easier for agents to parse than the rendered HTML
-site at https://simple-agent-lab.github.io/RSIHub/.
+site at https://simpleagentlab.com/RSIHub/.
 
 ## Docs
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: RSIHub
 site_description: Build agents that improve — and keep the evidence.
-site_url: https://simple-agent-lab.github.io/RSIHub/
+site_url: https://simpleagentlab.com/RSIHub/
 repo_url: https://github.com/simple-agent-lab/RSIHub
 repo_name: simple-agent-lab/RSIHub
 edit_uri: edit/main/docs/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,8 +26,8 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/simple-agent-lab/RSIHub"
-Documentation = "https://simple-agent-lab.github.io/RSIHub/"
+Homepage = "https://simpleagentlab.com/rsihub/"
+Documentation = "https://simpleagentlab.com/RSIHub/"
 Repository = "https://github.com/simple-agent-lab/RSIHub"
 Issues = "https://github.com/simple-agent-lab/RSIHub/issues"
 

--- a/tests/test_public_repository.py
+++ b/tests/test_public_repository.py
@@ -344,8 +344,8 @@ def test_license_metadata_and_notice_are_consistent() -> None:
     project = tomllib.loads((ROOT / "pyproject.toml").read_text())["project"]
     assert project["name"] == "rsihub"
     assert project["urls"] == {
-        "Homepage": "https://github.com/simple-agent-lab/RSIHub",
-        "Documentation": "https://simple-agent-lab.github.io/RSIHub/",
+        "Homepage": "https://simpleagentlab.com/rsihub/",
+        "Documentation": "https://simpleagentlab.com/RSIHub/",
         "Repository": "https://github.com/simple-agent-lab/RSIHub",
         "Issues": "https://github.com/simple-agent-lab/RSIHub/issues",
     }


### PR DESCRIPTION
## What changed

- point MkDocs canonical URLs and generated sitemap entries at `https://simpleagentlab.com/RSIHub/`
- link the README directly to the RSIHub product page and canonical documentation site
- update package homepage and documentation metadata
- remove remaining public references to the legacy `github.io` documentation URL

## Why

The documentation is served from the custom domain, but MkDocs and public metadata still advertised the legacy GitHub Pages host. Aligning these signals avoids split canonical and discovery signals while giving the product landing page a direct GitHub backlink.

## Validation

- `uv lock --check`
- `uv run --frozen pytest -q tests/test_public_repository.py` — 17 passed
- `uv run --frozen --group docs mkdocs build --strict`
- generated sitemap contains 22 URLs, all on `simpleagentlab.com`
- `uv run --frozen pytest -q` — 1233 passed, 3 skipped
- `uv run --frozen ruff check .`
- `uv run --frozen ruff format --check .`
- `uv run --frozen ty check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated project, documentation, and AI-agent resource links to the new `simpleagentlab.com/RSIHub/` website.
  - Refreshed homepage and documentation references across published project metadata.

- **Tests**
  - Updated URL checks to reflect the new project homepage and documentation locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->