### PR TITLE
Preserve configured Codex CLI version during install

### DIFF
--- a/src/evolve/integrations/harbor/codex_candidate.py
+++ b/src/evolve/integrations/harbor/codex_candidate.py
@@ -3,25 +3,12 @@
 from __future__ import annotations
 
 import shlex
-import shutil
-from pathlib import Path
 
 from harbor.agents.installed.codex import Codex
 
 
 class ResponsesCodexAgent(Codex):
     """Codex adapter for an OpenAI-compatible HTTP Responses endpoint."""
-
-    async def install(self, environment) -> None:
-        local_codex = shutil.which("codex")
-        if local_codex:
-            remote_codex = "/tmp/evolve-host-codex"
-            await environment.upload_file(Path(local_codex).resolve(), remote_codex)
-            await self.exec_as_root(
-                environment,
-                command=f"install -m 755 {shlex.quote(remote_codex)} /usr/local/bin/codex",
-            )
-        await super().install(environment)
 
     def build_cli_flags(self) -> str:
         base_url = self._get_env("OPENAI_BASE_URL") or self._get_env("OPENAI_API_BASE")

--- a/tests/test_codex_candidate.py
+++ b/tests/test_codex_candidate.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import importlib.util
 import os
 import sys
@@ -22,6 +23,9 @@ class FakeCodex:
 
     def build_cli_flags(self) -> str:
         return ""
+
+    async def install(self, environment) -> None:
+        environment.append("parent-install")
 
 
 def _load(monkeypatch):
@@ -58,6 +62,15 @@ def test_responses_codex_agent_configures_api_provider(monkeypatch) -> None:
     assert 'model_providers.evolve_http.wire_api="responses"' in flags
     assert 'model_providers.evolve_http.env_http_headers={"api-key"="OPENAI_API_KEY"}' in flags
     assert "model_providers.evolve_http.supports_websockets=false" in flags
+
+
+def test_responses_codex_agent_preserves_parent_versioned_install(monkeypatch) -> None:
+    module = _load(monkeypatch)
+    environment = []
+
+    asyncio.run(module.ResponsesCodexAgent().install(environment))
+
+    assert environment == ["parent-install"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- stop replacing the recipe-selected Codex CLI with whichever `codex` binary happens to be installed on the host
- delegate installation to Harbor's version-aware Codex installer
- add regression coverage proving the adapter preserves the parent versioned install path

## Why

A host CLI can differ from the version pinned by the target or mutator configuration, which breaks reproducibility. The adapter should honor the configured version.

## Validation

- `pytest -q tests/test_codex_candidate.py` — 4 passed
- `pytest -q tests/test_codex_candidate.py tests/test_runtime_auth.py tests/test_recipe_composition.py tests/test_coherence.py` — 48 passed with the project UV cache
- `ruff check src/evolve/integrations/harbor/codex_candidate.py tests/test_codex_candidate.py`
- `ruff format --check src/evolve/integrations/harbor/codex_candidate.py tests/test_codex_candidate.py`
- `git diff --check`
