### PR TITLE
docs: update benchmark results

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@
 
 <p align="center">
   <a href="docs/assets/benchmark-results-rsihub-v2.svg">
-    <img src="docs/assets/benchmark-results-rsihub-v2.svg" alt="Terminal Bench 2 and Tau cubed Banking results for AHE, Hyperagents, A-Evolve, and GEPA with MiniSWE and Codex target agents. Each stacked bar labels the seed score inside the dark section and the best score plus improvement above the light section.">
+    <img src="docs/assets/benchmark-results-rsihub-v2.svg" alt="Terminal Bench 2 and Tau cubed Banking results for AHE, Hyperagents, A-Evolve, and GEPA with MiniSWE and Codex target agents. Each stacked bar labels the seed score inside the dark section and the evolved score plus change above the light section.">
   </a>
 </p>
 
@@ -208,65 +208,65 @@ a GPT-5.4-xhigh Codex mutate operator.
       <td align="center" rowspan="4">Codex</td>
       <td align="center"><a href="https://arxiv.org/pdf/2604.25850">AHE</a></td>
       <td align="center">60.0%&nbsp;→&nbsp;74.0%&nbsp;<img src="docs/assets/benchmark-deltas/gain-percent-14-0.svg" alt="(+14.0)" width="68" height="20"></td>
-      <td align="center">60.7%&nbsp;→&nbsp;66.3%&nbsp;<img src="docs/assets/benchmark-deltas/gain-percent-5-6.svg" alt="(+5.6)" width="68" height="20"></td>
+      <td align="center">69.7%&nbsp;→&nbsp;71.9%&nbsp;<img src="docs/assets/benchmark-deltas/gain-percent-2-2.svg" alt="(+2.2)" width="68" height="20"></td>
     </tr>
     <tr>
       <td align="center"><a href="https://arxiv.org/abs/2603.19461">Hyperagents</a></td>
       <td align="center">58.0%&nbsp;→&nbsp;72.0%&nbsp;<img src="docs/assets/benchmark-deltas/gain-percent-14-0.svg" alt="(+14.0)" width="68" height="20"></td>
-      <td align="center">60.7%&nbsp;→&nbsp;70.8%&nbsp;<img src="docs/assets/benchmark-deltas/gain-percent-10-1.svg" alt="(+10.1)" width="68" height="20"></td>
+      <td align="center">69.7%&nbsp;→&nbsp;70.8%&nbsp;<img src="docs/assets/benchmark-deltas/gain-percent-1-1.svg" alt="(+1.1)" width="68" height="20"></td>
     </tr>
     <tr>
       <td align="center"><a href="https://github.com/A-EVO-Lab/a-evolve">A-Evolve</a></td>
       <td align="center">62.0%&nbsp;→&nbsp;62.0%&nbsp;<img src="docs/assets/benchmark-deltas/no-change-percent-0.svg" alt="(0.0)" width="68" height="20"></td>
-      <td align="center">60.7%&nbsp;→&nbsp;64.0%&nbsp;<img src="docs/assets/benchmark-deltas/gain-percent-3-3.svg" alt="(+3.3)" width="68" height="20"></td>
+      <td align="center">69.7%&nbsp;→&nbsp;70.8%&nbsp;<img src="docs/assets/benchmark-deltas/gain-percent-1-1.svg" alt="(+1.1)" width="68" height="20"></td>
     </tr>
     <tr>
       <td align="center"><a href="https://arxiv.org/abs/2507.19457">GEPA</a></td>
       <td align="center">64.0%&nbsp;→&nbsp;64.0%&nbsp;<img src="docs/assets/benchmark-deltas/no-change-percent-0.svg" alt="(0.0)" width="68" height="20"></td>
-      <td align="center">60.7%&nbsp;→&nbsp;60.7%&nbsp;<img src="docs/assets/benchmark-deltas/no-change-percent-0.svg" alt="(0.0)" width="68" height="20"></td>
+      <td align="center">69.7%&nbsp;→&nbsp;69.7%&nbsp;<img src="docs/assets/benchmark-deltas/no-change-percent-0.svg" alt="(0.0)" width="68" height="20"></td>
     </tr>
     <tr>
       <td align="center" rowspan="8"><strong>Tau³ Banking</strong><br><sub>50 train / 20 gate / 27 sealed</sub></td>
       <td align="center" rowspan="4">MiniSWE</td>
       <td align="center"><a href="https://arxiv.org/pdf/2604.25850">AHE</a></td>
-      <td align="center">34.0%&nbsp;→&nbsp;36.0%&nbsp;<img src="docs/assets/benchmark-deltas/gain-percent-2-0.svg" alt="(+2.0)" width="68" height="20"></td>
-      <td align="center">12.4%&nbsp;→&nbsp;22.7%&nbsp;<img src="docs/assets/benchmark-deltas/gain-percent-10-3.svg" alt="(+10.3)" width="68" height="20"></td>
+      <td align="center">0.0%&nbsp;→&nbsp;32.0%&nbsp;<img src="docs/assets/benchmark-deltas/gain-percent-32-0.svg" alt="(+32.0)" width="68" height="20"></td>
+      <td align="center">12.4%&nbsp;→&nbsp;33.0%&nbsp;<img src="docs/assets/benchmark-deltas/gain-percent-20-6.svg" alt="(+20.6)" width="68" height="20"></td>
     </tr>
     <tr>
       <td align="center"><a href="https://arxiv.org/abs/2603.19461">Hyperagents</a></td>
-      <td align="center">30.0%&nbsp;→&nbsp;38.0%&nbsp;<img src="docs/assets/benchmark-deltas/gain-percent-8-0.svg" alt="(+8.0)" width="68" height="20"></td>
+      <td align="center">2.0%&nbsp;→&nbsp;30.0%&nbsp;<img src="docs/assets/benchmark-deltas/gain-percent-28-0.svg" alt="(+28.0)" width="68" height="20"></td>
       <td align="center">12.4%&nbsp;→&nbsp;28.9%&nbsp;<img src="docs/assets/benchmark-deltas/gain-percent-16-5.svg" alt="(+16.5)" width="68" height="20"></td>
     </tr>
     <tr>
       <td align="center"><a href="https://github.com/A-EVO-Lab/a-evolve">A-Evolve</a></td>
-      <td align="center">30.0%&nbsp;→&nbsp;34.0%&nbsp;<img src="docs/assets/benchmark-deltas/gain-percent-4-0.svg" alt="(+4.0)" width="68" height="20"></td>
-      <td align="center">12.4%&nbsp;→&nbsp;24.7%&nbsp;<img src="docs/assets/benchmark-deltas/gain-percent-12-3.svg" alt="(+12.3)" width="68" height="20"></td>
+      <td align="center">2.0%&nbsp;→&nbsp;32.0%&nbsp;<img src="docs/assets/benchmark-deltas/gain-percent-30-0.svg" alt="(+30.0)" width="68" height="20"></td>
+      <td align="center">12.4%&nbsp;→&nbsp;21.7%&nbsp;<img src="docs/assets/benchmark-deltas/gain-percent-9-3.svg" alt="(+9.3)" width="68" height="20"></td>
     </tr>
     <tr>
       <td align="center"><a href="https://arxiv.org/abs/2507.19457">GEPA</a></td>
-      <td align="center">30.0%&nbsp;→&nbsp;32.0%&nbsp;<img src="docs/assets/benchmark-deltas/gain-percent-2-0.svg" alt="(+2.0)" width="68" height="20"></td>
-      <td align="center">12.4%&nbsp;→&nbsp;22.7%&nbsp;<img src="docs/assets/benchmark-deltas/gain-percent-10-3.svg" alt="(+10.3)" width="68" height="20"></td>
+      <td align="center">2.0%&nbsp;→&nbsp;22.0%&nbsp;<img src="docs/assets/benchmark-deltas/gain-percent-20-0.svg" alt="(+20.0)" width="68" height="20"></td>
+      <td align="center">12.4%&nbsp;→&nbsp;23.7%&nbsp;<img src="docs/assets/benchmark-deltas/gain-percent-11-3.svg" alt="(+11.3)" width="68" height="20"></td>
     </tr>
     <tr>
       <td align="center" rowspan="4">Codex</td>
       <td align="center"><a href="https://arxiv.org/pdf/2604.25850">AHE</a></td>
       <td align="center">32.0%&nbsp;→&nbsp;36.0%&nbsp;<img src="docs/assets/benchmark-deltas/gain-percent-4-0.svg" alt="(+4.0)" width="68" height="20"></td>
-      <td align="center">11.3%&nbsp;→&nbsp;26.8%&nbsp;<img src="docs/assets/benchmark-deltas/gain-percent-15-5.svg" alt="(+15.5)" width="68" height="20"></td>
+      <td align="center">24.7%&nbsp;→&nbsp;26.8%&nbsp;<img src="docs/assets/benchmark-deltas/gain-percent-2-1.svg" alt="(+2.1)" width="68" height="20"></td>
     </tr>
     <tr>
       <td align="center"><a href="https://arxiv.org/abs/2603.19461">Hyperagents</a></td>
       <td align="center">34.0%&nbsp;→&nbsp;36.0%&nbsp;<img src="docs/assets/benchmark-deltas/gain-percent-2-0.svg" alt="(+2.0)" width="68" height="20"></td>
-      <td align="center">11.3%&nbsp;→&nbsp;39.2%&nbsp;<img src="docs/assets/benchmark-deltas/gain-percent-27-9.svg" alt="(+27.9)" width="68" height="20"></td>
+      <td align="center">24.7%&nbsp;→&nbsp;39.2%&nbsp;<img src="docs/assets/benchmark-deltas/gain-percent-14-5.svg" alt="(+14.5)" width="68" height="20"></td>
     </tr>
     <tr>
       <td align="center"><a href="https://github.com/A-EVO-Lab/a-evolve">A-Evolve</a></td>
-      <td align="center">30.0%&nbsp;→&nbsp;38.0%&nbsp;<img src="docs/assets/benchmark-deltas/gain-percent-8-0.svg" alt="(+8.0)" width="68" height="20"></td>
-      <td align="center">11.3%&nbsp;→&nbsp;13.4%&nbsp;<img src="docs/assets/benchmark-deltas/gain-percent-2-1.svg" alt="(+2.1)" width="68" height="20"></td>
+      <td align="center">36.0%&nbsp;→&nbsp;38.0%&nbsp;<img src="docs/assets/benchmark-deltas/gain-percent-2-0.svg" alt="(+2.0)" width="68" height="20"></td>
+      <td align="center">24.7%&nbsp;→&nbsp;28.9%&nbsp;<img src="docs/assets/benchmark-deltas/gain-percent-4-2.svg" alt="(+4.2)" width="68" height="20"></td>
     </tr>
     <tr>
       <td align="center"><a href="https://arxiv.org/abs/2507.19457">GEPA</a></td>
-      <td align="center">10.0%&nbsp;→&nbsp;16.0%&nbsp;<img src="docs/assets/benchmark-deltas/gain-percent-6-0.svg" alt="(+6.0)" width="68" height="20"></td>
-      <td align="center">11.3%&nbsp;→&nbsp;15.5%&nbsp;<img src="docs/assets/benchmark-deltas/gain-percent-4-2.svg" alt="(+4.2)" width="68" height="20"></td>
+      <td align="center">28.0%&nbsp;→&nbsp;30.0%&nbsp;<img src="docs/assets/benchmark-deltas/gain-percent-2-0.svg" alt="(+2.0)" width="68" height="20"></td>
+      <td align="center">24.7%&nbsp;→&nbsp;33.0%&nbsp;<img src="docs/assets/benchmark-deltas/gain-percent-8-3.svg" alt="(+8.3)" width="68" height="20"></td>
     </tr>
   </tbody>
 </table>

--- a/docs/assets/benchmark-deltas/gain-percent-11-3.svg
+++ b/docs/assets/benchmark-deltas/gain-percent-11-3.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="68" height="20" viewBox="0 0 68 20" role="img" aria-label="(+11.3)">
+  <style>
+    text { fill: #7c3aed; font: 700 14px Inter, ui-sans-serif, system-ui, sans-serif; }
+    @media (prefers-color-scheme: dark) { text { fill: #a78bfa; } }
+  </style>
+  <text x="34" y="18" text-anchor="middle">(+11.3)</text>
+</svg>

--- a/docs/assets/benchmark-deltas/gain-percent-14-5.svg
+++ b/docs/assets/benchmark-deltas/gain-percent-14-5.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="68" height="20" viewBox="0 0 68 20" role="img" aria-label="(+14.5)">
+  <style>
+    text { fill: #7c3aed; font: 700 14px Inter, ui-sans-serif, system-ui, sans-serif; }
+    @media (prefers-color-scheme: dark) { text { fill: #a78bfa; } }
+  </style>
+  <text x="34" y="18" text-anchor="middle">(+14.5)</text>
+</svg>

--- a/docs/assets/benchmark-deltas/gain-percent-2-2.svg
+++ b/docs/assets/benchmark-deltas/gain-percent-2-2.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="68" height="20" viewBox="0 0 68 20" role="img" aria-label="(+2.2)">
+  <style>
+    text { fill: #7c3aed; font: 700 14px Inter, ui-sans-serif, system-ui, sans-serif; }
+    @media (prefers-color-scheme: dark) { text { fill: #a78bfa; } }
+  </style>
+  <text x="34" y="18" text-anchor="middle">(+2.2)</text>
+</svg>

--- a/docs/assets/benchmark-deltas/gain-percent-20-0.svg
+++ b/docs/assets/benchmark-deltas/gain-percent-20-0.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="68" height="20" viewBox="0 0 68 20" role="img" aria-label="(+20.0)">
+  <style>
+    text { fill: #7c3aed; font: 700 14px Inter, ui-sans-serif, system-ui, sans-serif; }
+    @media (prefers-color-scheme: dark) { text { fill: #a78bfa; } }
+  </style>
+  <text x="34" y="18" text-anchor="middle">(+20.0)</text>
+</svg>

--- a/docs/assets/benchmark-deltas/gain-percent-20-6.svg
+++ b/docs/assets/benchmark-deltas/gain-percent-20-6.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="68" height="20" viewBox="0 0 68 20" role="img" aria-label="(+20.6)">
+  <style>
+    text { fill: #7c3aed; font: 700 14px Inter, ui-sans-serif, system-ui, sans-serif; }
+    @media (prefers-color-scheme: dark) { text { fill: #a78bfa; } }
+  </style>
+  <text x="34" y="18" text-anchor="middle">(+20.6)</text>
+</svg>

--- a/docs/assets/benchmark-deltas/gain-percent-28-0.svg
+++ b/docs/assets/benchmark-deltas/gain-percent-28-0.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="68" height="20" viewBox="0 0 68 20" role="img" aria-label="(+28.0)">
+  <style>
+    text { fill: #7c3aed; font: 700 14px Inter, ui-sans-serif, system-ui, sans-serif; }
+    @media (prefers-color-scheme: dark) { text { fill: #a78bfa; } }
+  </style>
+  <text x="34" y="18" text-anchor="middle">(+28.0)</text>
+</svg>

--- a/docs/assets/benchmark-deltas/gain-percent-30-0.svg
+++ b/docs/assets/benchmark-deltas/gain-percent-30-0.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="68" height="20" viewBox="0 0 68 20" role="img" aria-label="(+30.0)">
+  <style>
+    text { fill: #7c3aed; font: 700 14px Inter, ui-sans-serif, system-ui, sans-serif; }
+    @media (prefers-color-scheme: dark) { text { fill: #a78bfa; } }
+  </style>
+  <text x="34" y="18" text-anchor="middle">(+30.0)</text>
+</svg>

--- a/docs/assets/benchmark-deltas/gain-percent-32-0.svg
+++ b/docs/assets/benchmark-deltas/gain-percent-32-0.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="68" height="20" viewBox="0 0 68 20" role="img" aria-label="(+32.0)">
+  <style>
+    text { fill: #7c3aed; font: 700 14px Inter, ui-sans-serif, system-ui, sans-serif; }
+    @media (prefers-color-scheme: dark) { text { fill: #a78bfa; } }
+  </style>
+  <text x="34" y="18" text-anchor="middle">(+32.0)</text>
+</svg>

--- a/docs/assets/benchmark-deltas/gain-percent-8-3.svg
+++ b/docs/assets/benchmark-deltas/gain-percent-8-3.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="68" height="20" viewBox="0 0 68 20" role="img" aria-label="(+8.3)">
+  <style>
+    text { fill: #7c3aed; font: 700 14px Inter, ui-sans-serif, system-ui, sans-serif; }
+    @media (prefers-color-scheme: dark) { text { fill: #a78bfa; } }
+  </style>
+  <text x="34" y="18" text-anchor="middle">(+8.3)</text>
+</svg>

--- a/docs/assets/benchmark-deltas/gain-percent-9-3.svg
+++ b/docs/assets/benchmark-deltas/gain-percent-9-3.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="68" height="20" viewBox="0 0 68 20" role="img" aria-label="(+9.3)">
+  <style>
+    text { fill: #7c3aed; font: 700 14px Inter, ui-sans-serif, system-ui, sans-serif; }
+    @media (prefers-color-scheme: dark) { text { fill: #a78bfa; } }
+  </style>
+  <text x="34" y="18" text-anchor="middle">(+9.3)</text>
+</svg>

--- a/docs/assets/benchmark-results-rsihub-v2.svg
+++ b/docs/assets/benchmark-results-rsihub-v2.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1600" height="790" viewBox="0 0 1600 790" role="img" aria-labelledby="title desc">
 <title id="title">RSIHub benchmark results</title>
-<desc id="desc">Terminal Bench 2 and Tau cubed Banking results for four evolution methods with MiniSWE and Codex target agents. MiniSWE is grouped left and Codex right in each panel. The vertical axes use truncated ranges (50–80% and 5–45%). Dark bar sections show seed scores above each axis baseline; light sections show improvement to the best score.</desc>
+<desc id="desc">Full-benchmark scores on Terminal Bench 2 and Tau cubed Banking for four evolution methods with MiniSWE and Codex target agents. MiniSWE is grouped left and Codex right in each panel. The vertical axes use truncated ranges (50–80% and 5–45%). Dark bar sections show seed scores above each axis baseline; light sections show improvement to the evolved score.</desc>
 <rect width="1600" height="790" rx="18" fill="#F2FBF7"/>
 <style>text{font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}.title{font-size:25px;font-weight:750;fill:#19785A}.axis{font-size:12px;fill:#608675}.method{font-size:16px;font-weight:750;fill:#607169}.seed{font-size:16px;font-weight:800;fill:#FFFFFF}.best{font-size:16px;font-weight:800;fill:#19785A}.delta-up{fill:#7C3AED}.delta-down{fill:#CF222E}.delta-flat{fill:#9A6700}.agent{font-size:17px;font-weight:800}.legend{font-size:13px;font-weight:650;fill:#607169}.note{font-size:12px;fill:#608675}</style>
 <text class="title" x="427.5" y="72" text-anchor="middle">Terminal Bench 2</text>
@@ -24,43 +24,43 @@
 <defs><clipPath id="b-0-0-0"><rect x="83.7" y="491.2" width="58" height="98.8" rx="5"/></clipPath></defs>
 <g clip-path="url(#b-0-0-0)"><rect x="83.7" y="491.2" width="58" height="17.5" fill="#65CE9F"/><rect x="83.7" y="508.7" width="58" height="81.3" fill="#19785A"/></g>
 <text class="seed" x="112.7" y="527.7" text-anchor="middle">55.1</text>
-<text class="best" x="112.7" y="468.2" text-anchor="middle"><tspan x="112.7">56.2</tspan><tspan class="delta-up" style="fill:#7C3AED" x="112.7" dy="17">(+1.1)</tspan></text>
+<text class="best" x="112.7" y="468.2" text-anchor="middle"><tspan x="112.7">56.2</tspan><tspan class="delta-up" x="112.7" dy="17">(+1.1)</tspan></text>
 <text class="method" x="112.7" y="608" text-anchor="end" transform="rotate(-45 112.7 608)">AHE</text>
 <defs><clipPath id="b-0-0-1"><rect x="169.1" y="295.2" width="58" height="294.8" rx="5"/></clipPath></defs>
 <g clip-path="url(#b-0-0-1)"><rect x="169.1" y="295.2" width="58" height="213.5" fill="#65CE9F"/><rect x="169.1" y="508.7" width="58" height="81.3" fill="#19785A"/></g>
 <text class="seed" x="198.1" y="527.7" text-anchor="middle">55.1</text>
-<text class="best" x="198.1" y="272.2" text-anchor="middle"><tspan x="198.1">68.5</tspan><tspan class="delta-up" style="fill:#7C3AED" x="198.1" dy="17">(+13.4)</tspan></text>
+<text class="best" x="198.1" y="272.2" text-anchor="middle"><tspan x="198.1">68.5</tspan><tspan class="delta-up" x="198.1" dy="17">(+13.4)</tspan></text>
 <text class="method" x="198.1" y="608" text-anchor="end" transform="rotate(-45 198.1 608)">Hyperagents</text>
 <defs><clipPath id="b-0-0-2"><rect x="254.4" y="347.8" width="58" height="242.2" rx="5"/></clipPath></defs>
 <g clip-path="url(#b-0-0-2)"><rect x="254.4" y="347.8" width="58" height="160.9" fill="#65CE9F"/><rect x="254.4" y="508.7" width="58" height="81.3" fill="#19785A"/></g>
 <text class="seed" x="283.4" y="527.7" text-anchor="middle">55.1</text>
-<text class="best" x="283.4" y="324.8" text-anchor="middle"><tspan x="283.4">65.2</tspan><tspan class="delta-up" style="fill:#7C3AED" x="283.4" dy="17">(+10.1)</tspan></text>
+<text class="best" x="283.4" y="324.8" text-anchor="middle"><tspan x="283.4">65.2</tspan><tspan class="delta-up" x="283.4" dy="17">(+10.1)</tspan></text>
 <text class="method" x="283.4" y="608" text-anchor="end" transform="rotate(-45 283.4 608)">A-Evolve</text>
 <defs><clipPath id="b-0-0-3"><rect x="339.8" y="437.0" width="58" height="153.0" rx="5"/></clipPath></defs>
 <g clip-path="url(#b-0-0-3)"><rect x="339.8" y="437.0" width="58" height="71.7" fill="#65CE9F"/><rect x="339.8" y="508.7" width="58" height="81.3" fill="#19785A"/></g>
 <text class="seed" x="368.8" y="527.7" text-anchor="middle">55.1</text>
-<text class="best" x="368.8" y="414.0" text-anchor="middle"><tspan x="368.8">59.6</tspan><tspan class="delta-up" style="fill:#7C3AED" x="368.8" dy="17">(+4.5)</tspan></text>
+<text class="best" x="368.8" y="414.0" text-anchor="middle"><tspan x="368.8">59.6</tspan><tspan class="delta-up" x="368.8" dy="17">(+4.5)</tspan></text>
 <text class="method" x="368.8" y="608" text-anchor="end" transform="rotate(-45 368.8 608)">GEPA</text>
 <text class="agent" x="614.2" y="101" text-anchor="middle" fill="#608675">Codex</text>
-<defs><clipPath id="b-0-1-0"><rect x="457.2" y="330.3" width="58" height="259.7" rx="5"/></clipPath></defs>
-<g clip-path="url(#b-0-1-0)"><rect x="457.2" y="330.3" width="58" height="89.2" fill="#B8D8C9"/><rect x="457.2" y="419.5" width="58" height="170.5" fill="#608675"/></g>
-<text class="seed" x="486.2" y="438.5" text-anchor="middle">60.7</text>
-<text class="best" x="486.2" y="307.3" text-anchor="middle"><tspan x="486.2">66.3</tspan><tspan class="delta-up" style="fill:#7C3AED" x="486.2" dy="17">(+5.6)</tspan></text>
+<defs><clipPath id="b-0-1-0"><rect x="457.2" y="241.1" width="58" height="348.9" rx="5"/></clipPath></defs>
+<g clip-path="url(#b-0-1-0)"><rect x="457.2" y="241.1" width="58" height="35.1" fill="#B8D8C9"/><rect x="457.2" y="276.1" width="58" height="313.9" fill="#608675"/></g>
+<text class="seed" x="486.2" y="295.1" text-anchor="middle">69.7</text>
+<text class="best" x="486.2" y="218.1" text-anchor="middle"><tspan x="486.2">71.9</tspan><tspan class="delta-up" x="486.2" dy="17">(+2.2)</tspan></text>
 <text class="method" x="486.2" y="608" text-anchor="end" transform="rotate(-45 486.2 608)">AHE</text>
 <defs><clipPath id="b-0-1-1"><rect x="542.6" y="258.6" width="58" height="331.4" rx="5"/></clipPath></defs>
-<g clip-path="url(#b-0-1-1)"><rect x="542.6" y="258.6" width="58" height="160.9" fill="#B8D8C9"/><rect x="542.6" y="419.5" width="58" height="170.5" fill="#608675"/></g>
-<text class="seed" x="571.6" y="438.5" text-anchor="middle">60.7</text>
-<text class="best" x="571.6" y="235.6" text-anchor="middle"><tspan x="571.6">70.8</tspan><tspan class="delta-up" style="fill:#7C3AED" x="571.6" dy="17">(+10.1)</tspan></text>
+<g clip-path="url(#b-0-1-1)"><rect x="542.6" y="258.6" width="58" height="17.5" fill="#B8D8C9"/><rect x="542.6" y="276.1" width="58" height="313.9" fill="#608675"/></g>
+<text class="seed" x="571.6" y="295.1" text-anchor="middle">69.7</text>
+<text class="best" x="571.6" y="235.6" text-anchor="middle"><tspan x="571.6">70.8</tspan><tspan class="delta-up" x="571.6" dy="17">(+1.1)</tspan></text>
 <text class="method" x="571.6" y="608" text-anchor="end" transform="rotate(-45 571.6 608)">Hyperagents</text>
-<defs><clipPath id="b-0-1-2"><rect x="627.9" y="366.9" width="58" height="223.1" rx="5"/></clipPath></defs>
-<g clip-path="url(#b-0-1-2)"><rect x="627.9" y="366.9" width="58" height="52.6" fill="#B8D8C9"/><rect x="627.9" y="419.5" width="58" height="170.5" fill="#608675"/></g>
-<text class="seed" x="656.9" y="438.5" text-anchor="middle">60.7</text>
-<text class="best" x="656.9" y="343.9" text-anchor="middle"><tspan x="656.9">64.0</tspan><tspan class="delta-up" style="fill:#7C3AED" x="656.9" dy="17">(+3.3)</tspan></text>
+<defs><clipPath id="b-0-1-2"><rect x="627.9" y="258.6" width="58" height="331.4" rx="5"/></clipPath></defs>
+<g clip-path="url(#b-0-1-2)"><rect x="627.9" y="258.6" width="58" height="17.5" fill="#B8D8C9"/><rect x="627.9" y="276.1" width="58" height="313.9" fill="#608675"/></g>
+<text class="seed" x="656.9" y="295.1" text-anchor="middle">69.7</text>
+<text class="best" x="656.9" y="235.6" text-anchor="middle"><tspan x="656.9">70.8</tspan><tspan class="delta-up" x="656.9" dy="17">(+1.1)</tspan></text>
 <text class="method" x="656.9" y="608" text-anchor="end" transform="rotate(-45 656.9 608)">A-Evolve</text>
-<defs><clipPath id="b-0-1-3"><rect x="713.3" y="419.5" width="58" height="170.5" rx="5"/></clipPath></defs>
-<g clip-path="url(#b-0-1-3)"><rect x="713.3" y="419.5" width="58" height="0.0" fill="#B8D8C9"/><rect x="713.3" y="419.5" width="58" height="170.5" fill="#608675"/></g>
-<text class="seed" x="742.3" y="438.5" text-anchor="middle">60.7</text>
-<text class="best" x="742.3" y="396.5" text-anchor="middle"><tspan x="742.3">60.7</tspan><tspan class="delta-flat" x="742.3" dy="17">(0.0)</tspan></text>
+<defs><clipPath id="b-0-1-3"><rect x="713.3" y="276.1" width="58" height="313.9" rx="5"/></clipPath></defs>
+<g clip-path="url(#b-0-1-3)"><rect x="713.3" y="276.1" width="58" height="0.0" fill="#B8D8C9"/><rect x="713.3" y="276.1" width="58" height="313.9" fill="#608675"/></g>
+<text class="seed" x="742.3" y="295.1" text-anchor="middle">69.7</text>
+<text class="best" x="742.3" y="253.1" text-anchor="middle"><tspan x="742.3">69.7</tspan><tspan class="delta-flat" x="742.3" dy="17">(0.0)</tspan></text>
 <text class="method" x="742.3" y="608" text-anchor="end" transform="rotate(-45 742.3 608)">GEPA</text>
 <text class="title" x="1212.5" y="72" text-anchor="middle">Tau³ Banking</text>
 <line x1="855.0" y1="590.0" x2="1570.0" y2="590.0" stroke="#D8EBE2"/>
@@ -84,46 +84,46 @@
 <line x1="855.0" y1="590" x2="1570.0" y2="590" stroke="#608675" stroke-width="1.2"/>
 <line x1="1212.5" y1="112" x2="1212.5" y2="637" stroke="#B7D0C4" stroke-dasharray="4 6"/>
 <text class="agent" x="1025.8" y="101" text-anchor="middle" fill="#19785A">MiniSWE</text>
-<defs><clipPath id="b-1-0-0"><rect x="868.7" y="378.5" width="58" height="211.5" rx="5"/></clipPath></defs>
-<g clip-path="url(#b-1-0-0)"><rect x="868.7" y="378.5" width="58" height="123.1" fill="#65CE9F"/><rect x="868.7" y="501.6" width="58" height="88.4" fill="#19785A"/></g>
+<defs><clipPath id="b-1-0-0"><rect x="868.7" y="255.4" width="58" height="334.6" rx="5"/></clipPath></defs>
+<g clip-path="url(#b-1-0-0)"><rect x="868.7" y="255.4" width="58" height="246.2" fill="#65CE9F"/><rect x="868.7" y="501.6" width="58" height="88.4" fill="#19785A"/></g>
 <text class="seed" x="897.7" y="520.6" text-anchor="middle">12.4</text>
-<text class="best" x="897.7" y="355.5" text-anchor="middle"><tspan x="897.7">22.7</tspan><tspan class="delta-up" style="fill:#7C3AED" x="897.7" dy="17">(+10.3)</tspan></text>
+<text class="best" x="897.7" y="232.4" text-anchor="middle"><tspan x="897.7">33.0</tspan><tspan class="delta-up" x="897.7" dy="17">(+20.6)</tspan></text>
 <text class="method" x="897.7" y="608" text-anchor="end" transform="rotate(-45 897.7 608)">AHE</text>
 <defs><clipPath id="b-1-0-1"><rect x="954.1" y="304.4" width="58" height="285.6" rx="5"/></clipPath></defs>
 <g clip-path="url(#b-1-0-1)"><rect x="954.1" y="304.4" width="58" height="197.2" fill="#65CE9F"/><rect x="954.1" y="501.6" width="58" height="88.4" fill="#19785A"/></g>
 <text class="seed" x="983.1" y="520.6" text-anchor="middle">12.4</text>
-<text class="best" x="983.1" y="281.4" text-anchor="middle"><tspan x="983.1">28.9</tspan><tspan class="delta-up" style="fill:#7C3AED" x="983.1" dy="17">(+16.5)</tspan></text>
+<text class="best" x="983.1" y="281.4" text-anchor="middle"><tspan x="983.1">28.9</tspan><tspan class="delta-up" x="983.1" dy="17">(+16.5)</tspan></text>
 <text class="method" x="983.1" y="608" text-anchor="end" transform="rotate(-45 983.1 608)">Hyperagents</text>
-<defs><clipPath id="b-1-0-2"><rect x="1039.4" y="354.6" width="58" height="235.4" rx="5"/></clipPath></defs>
-<g clip-path="url(#b-1-0-2)"><rect x="1039.4" y="354.6" width="58" height="147.0" fill="#65CE9F"/><rect x="1039.4" y="501.6" width="58" height="88.4" fill="#19785A"/></g>
+<defs><clipPath id="b-1-0-2"><rect x="1039.4" y="390.4" width="58" height="199.6" rx="5"/></clipPath></defs>
+<g clip-path="url(#b-1-0-2)"><rect x="1039.4" y="390.4" width="58" height="111.1" fill="#65CE9F"/><rect x="1039.4" y="501.6" width="58" height="88.4" fill="#19785A"/></g>
 <text class="seed" x="1068.4" y="520.6" text-anchor="middle">12.4</text>
-<text class="best" x="1068.4" y="331.6" text-anchor="middle"><tspan x="1068.4">24.7</tspan><tspan class="delta-up" style="fill:#7C3AED" x="1068.4" dy="17">(+12.3)</tspan></text>
+<text class="best" x="1068.4" y="367.4" text-anchor="middle"><tspan x="1068.4">21.7</tspan><tspan class="delta-up" x="1068.4" dy="17">(+9.3)</tspan></text>
 <text class="method" x="1068.4" y="608" text-anchor="end" transform="rotate(-45 1068.4 608)">A-Evolve</text>
-<defs><clipPath id="b-1-0-3"><rect x="1124.8" y="378.5" width="58" height="211.5" rx="5"/></clipPath></defs>
-<g clip-path="url(#b-1-0-3)"><rect x="1124.8" y="378.5" width="58" height="123.1" fill="#65CE9F"/><rect x="1124.8" y="501.6" width="58" height="88.4" fill="#19785A"/></g>
+<defs><clipPath id="b-1-0-3"><rect x="1124.8" y="366.5" width="58" height="223.5" rx="5"/></clipPath></defs>
+<g clip-path="url(#b-1-0-3)"><rect x="1124.8" y="366.5" width="58" height="135.0" fill="#65CE9F"/><rect x="1124.8" y="501.6" width="58" height="88.4" fill="#19785A"/></g>
 <text class="seed" x="1153.8" y="520.6" text-anchor="middle">12.4</text>
-<text class="best" x="1153.8" y="355.5" text-anchor="middle"><tspan x="1153.8">22.7</tspan><tspan class="delta-up" style="fill:#7C3AED" x="1153.8" dy="17">(+10.3)</tspan></text>
+<text class="best" x="1153.8" y="343.5" text-anchor="middle"><tspan x="1153.8">23.7</tspan><tspan class="delta-up" x="1153.8" dy="17">(+11.3)</tspan></text>
 <text class="method" x="1153.8" y="608" text-anchor="end" transform="rotate(-45 1153.8 608)">GEPA</text>
 <text class="agent" x="1399.2" y="101" text-anchor="middle" fill="#608675">Codex</text>
 <defs><clipPath id="b-1-1-0"><rect x="1242.2" y="329.5" width="58" height="260.5" rx="5"/></clipPath></defs>
-<g clip-path="url(#b-1-1-0)"><rect x="1242.2" y="329.5" width="58" height="185.2" fill="#B8D8C9"/><rect x="1242.2" y="514.7" width="58" height="75.3" fill="#608675"/></g>
-<text class="seed" x="1271.2" y="533.7" text-anchor="middle">11.3</text>
-<text class="best" x="1271.2" y="306.5" text-anchor="middle"><tspan x="1271.2">26.8</tspan><tspan class="delta-up" style="fill:#7C3AED" x="1271.2" dy="17">(+15.5)</tspan></text>
+<g clip-path="url(#b-1-1-0)"><rect x="1242.2" y="329.5" width="58" height="25.1" fill="#B8D8C9"/><rect x="1242.2" y="354.6" width="58" height="235.4" fill="#608675"/></g>
+<text class="seed" x="1271.2" y="373.6" text-anchor="middle">24.7</text>
+<text class="best" x="1271.2" y="306.5" text-anchor="middle"><tspan x="1271.2">26.8</tspan><tspan class="delta-up" x="1271.2" dy="17">(+2.1)</tspan></text>
 <text class="method" x="1271.2" y="608" text-anchor="end" transform="rotate(-45 1271.2 608)">AHE</text>
 <defs><clipPath id="b-1-1-1"><rect x="1327.6" y="181.3" width="58" height="408.7" rx="5"/></clipPath></defs>
-<g clip-path="url(#b-1-1-1)"><rect x="1327.6" y="181.3" width="58" height="333.4" fill="#B8D8C9"/><rect x="1327.6" y="514.7" width="58" height="75.3" fill="#608675"/></g>
-<text class="seed" x="1356.6" y="533.7" text-anchor="middle">11.3</text>
-<text class="best" x="1356.6" y="158.3" text-anchor="middle"><tspan x="1356.6">39.2</tspan><tspan class="delta-up" style="fill:#7C3AED" x="1356.6" dy="17">(+27.9)</tspan></text>
+<g clip-path="url(#b-1-1-1)"><rect x="1327.6" y="181.3" width="58" height="173.3" fill="#B8D8C9"/><rect x="1327.6" y="354.6" width="58" height="235.4" fill="#608675"/></g>
+<text class="seed" x="1356.6" y="373.6" text-anchor="middle">24.7</text>
+<text class="best" x="1356.6" y="158.3" text-anchor="middle"><tspan x="1356.6">39.2</tspan><tspan class="delta-up" x="1356.6" dy="17">(+14.5)</tspan></text>
 <text class="method" x="1356.6" y="608" text-anchor="end" transform="rotate(-45 1356.6 608)">Hyperagents</text>
-<defs><clipPath id="b-1-1-2"><rect x="1412.9" y="489.6" width="58" height="100.4" rx="5"/></clipPath></defs>
-<g clip-path="url(#b-1-1-2)"><rect x="1412.9" y="489.6" width="58" height="25.1" fill="#B8D8C9"/><rect x="1412.9" y="514.7" width="58" height="75.3" fill="#608675"/></g>
-<text class="seed" x="1441.9" y="533.7" text-anchor="middle">11.3</text>
-<text class="best" x="1441.9" y="466.6" text-anchor="middle"><tspan x="1441.9">13.4</tspan><tspan class="delta-up" style="fill:#7C3AED" x="1441.9" dy="17">(+2.1)</tspan></text>
+<defs><clipPath id="b-1-1-2"><rect x="1412.9" y="304.4" width="58" height="285.6" rx="5"/></clipPath></defs>
+<g clip-path="url(#b-1-1-2)"><rect x="1412.9" y="304.4" width="58" height="50.2" fill="#B8D8C9"/><rect x="1412.9" y="354.6" width="58" height="235.4" fill="#608675"/></g>
+<text class="seed" x="1441.9" y="373.6" text-anchor="middle">24.7</text>
+<text class="best" x="1441.9" y="281.4" text-anchor="middle"><tspan x="1441.9">28.9</tspan><tspan class="delta-up" x="1441.9" dy="17">(+4.2)</tspan></text>
 <text class="method" x="1441.9" y="608" text-anchor="end" transform="rotate(-45 1441.9 608)">A-Evolve</text>
-<defs><clipPath id="b-1-1-3"><rect x="1498.3" y="464.5" width="58" height="125.5" rx="5"/></clipPath></defs>
-<g clip-path="url(#b-1-1-3)"><rect x="1498.3" y="464.5" width="58" height="50.2" fill="#B8D8C9"/><rect x="1498.3" y="514.7" width="58" height="75.3" fill="#608675"/></g>
-<text class="seed" x="1527.3" y="533.7" text-anchor="middle">11.3</text>
-<text class="best" x="1527.3" y="441.5" text-anchor="middle"><tspan x="1527.3">15.5</tspan><tspan class="delta-up" style="fill:#7C3AED" x="1527.3" dy="17">(+4.2)</tspan></text>
+<defs><clipPath id="b-1-1-3"><rect x="1498.3" y="255.4" width="58" height="334.6" rx="5"/></clipPath></defs>
+<g clip-path="url(#b-1-1-3)"><rect x="1498.3" y="255.4" width="58" height="99.2" fill="#B8D8C9"/><rect x="1498.3" y="354.6" width="58" height="235.4" fill="#608675"/></g>
+<text class="seed" x="1527.3" y="373.6" text-anchor="middle">24.7</text>
+<text class="best" x="1527.3" y="232.4" text-anchor="middle"><tspan x="1527.3">33.0</tspan><tspan class="delta-up" x="1527.3" dy="17">(+8.3)</tspan></text>
 <text class="method" x="1527.3" y="608" text-anchor="end" transform="rotate(-45 1527.3 608)">GEPA</text>
 <defs><clipPath id="legend-0"><rect x="698" y="700" width="26" height="22" rx="5"/></clipPath></defs>
 <g clip-path="url(#legend-0)"><rect x="698" y="700" width="26" height="11" fill="#65CE9F"/><rect x="698" y="711" width="26" height="11" fill="#19785A"/></g>
@@ -131,5 +131,5 @@
 <defs><clipPath id="legend-1"><rect x="832" y="700" width="26" height="22" rx="5"/></clipPath></defs>
 <g clip-path="url(#legend-1)"><rect x="832" y="700" width="26" height="11" fill="#B8D8C9"/><rect x="832" y="711" width="26" height="11" fill="#608675"/></g>
 <text class="legend" x="868" y="717">Codex</text>
-<text class="note" x="800" y="766" text-anchor="middle">dark = seed · light = improvement · labels show best (change) · target: GPT-5.4-high · meta: GPT-5.4-xhigh</text>
+<text class="note" x="800" y="766" text-anchor="middle">dark = seed · light = improvement · labels show evolved score (change) · target: GPT-5.4-high · meta: GPT-5.4-xhigh</text>
 </svg>


### PR DESCRIPTION
## Summary

- update the README benchmark table with the revised Terminal-Bench 2 and Tau³ Banking train/full-benchmark scores
- keep the table ordered as Train Score followed by Full Benchmark Score
- refresh the benchmark chart with the revised full-benchmark baselines, evolved scores, and deltas
- add the missing colored delta-label SVG assets used by the table

## Impact

The README now presents the latest benchmark values consistently in both the table and the chart while preserving the existing target-agent grouping and visual language.

## Validation

- validated all 16 table rows against the supplied data
- validated all local README image references
- parsed the benchmark SVG as XML and checked its plotted labels
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated benchmark result tables with refreshed seed scores, evolved scores, and change indicators for Terminal-Bench 2 and Tau³ Banking.
  - Corrected benchmark chart alt text to accurately describe the light section of stacked bars.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->