### PR TITLE
docs: correct Tau3 benchmark baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,22 +230,22 @@ a GPT-5.4-xhigh Codex mutate operator.
       <td align="center" rowspan="4">MiniSWE</td>
       <td align="center"><a href="https://arxiv.org/pdf/2604.25850">AHE</a></td>
       <td align="center">0.0%&nbsp;→&nbsp;32.0%&nbsp;<img src="docs/assets/benchmark-deltas/gain-percent-32-0.svg" alt="(+32.0)" width="68" height="20"></td>
-      <td align="center">12.4%&nbsp;→&nbsp;33.0%&nbsp;<img src="docs/assets/benchmark-deltas/gain-percent-20-6.svg" alt="(+20.6)" width="68" height="20"></td>
+      <td align="center">3.1%&nbsp;→&nbsp;33.0%&nbsp;<img src="docs/assets/benchmark-deltas/gain-percent-29-9.svg" alt="(+29.9)" width="68" height="20"></td>
     </tr>
     <tr>
       <td align="center"><a href="https://arxiv.org/abs/2603.19461">Hyperagents</a></td>
       <td align="center">2.0%&nbsp;→&nbsp;30.0%&nbsp;<img src="docs/assets/benchmark-deltas/gain-percent-28-0.svg" alt="(+28.0)" width="68" height="20"></td>
-      <td align="center">12.4%&nbsp;→&nbsp;28.9%&nbsp;<img src="docs/assets/benchmark-deltas/gain-percent-16-5.svg" alt="(+16.5)" width="68" height="20"></td>
+      <td align="center">3.1%&nbsp;→&nbsp;28.9%&nbsp;<img src="docs/assets/benchmark-deltas/gain-percent-25-8.svg" alt="(+25.8)" width="68" height="20"></td>
     </tr>
     <tr>
       <td align="center"><a href="https://github.com/A-EVO-Lab/a-evolve">A-Evolve</a></td>
       <td align="center">2.0%&nbsp;→&nbsp;32.0%&nbsp;<img src="docs/assets/benchmark-deltas/gain-percent-30-0.svg" alt="(+30.0)" width="68" height="20"></td>
-      <td align="center">12.4%&nbsp;→&nbsp;21.7%&nbsp;<img src="docs/assets/benchmark-deltas/gain-percent-9-3.svg" alt="(+9.3)" width="68" height="20"></td>
+      <td align="center">3.1%&nbsp;→&nbsp;21.7%&nbsp;<img src="docs/assets/benchmark-deltas/gain-percent-18-6.svg" alt="(+18.6)" width="68" height="20"></td>
     </tr>
     <tr>
       <td align="center"><a href="https://arxiv.org/abs/2507.19457">GEPA</a></td>
       <td align="center">2.0%&nbsp;→&nbsp;22.0%&nbsp;<img src="docs/assets/benchmark-deltas/gain-percent-20-0.svg" alt="(+20.0)" width="68" height="20"></td>
-      <td align="center">12.4%&nbsp;→&nbsp;23.7%&nbsp;<img src="docs/assets/benchmark-deltas/gain-percent-11-3.svg" alt="(+11.3)" width="68" height="20"></td>
+      <td align="center">3.1%&nbsp;→&nbsp;23.7%&nbsp;<img src="docs/assets/benchmark-deltas/gain-percent-20-6.svg" alt="(+20.6)" width="68" height="20"></td>
     </tr>
     <tr>
       <td align="center" rowspan="4">Codex</td>

--- a/docs/assets/benchmark-deltas/gain-percent-18-6.svg
+++ b/docs/assets/benchmark-deltas/gain-percent-18-6.svg
@@ -1,7 +1,7 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="68" height="20" viewBox="0 0 68 20" role="img" aria-label="(+9.3)">
+<svg xmlns="http://www.w3.org/2000/svg" width="68" height="20" viewBox="0 0 68 20" role="img" aria-label="(+18.6)">
   <style>
     text { fill: #7c3aed; font: 700 14px Inter, ui-sans-serif, system-ui, sans-serif; }
     @media (prefers-color-scheme: dark) { text { fill: #a78bfa; } }
   </style>
-  <text x="34" y="18" text-anchor="middle">(+9.3)</text>
+  <text x="34" y="18" text-anchor="middle">(+18.6)</text>
 </svg>

--- a/docs/assets/benchmark-deltas/gain-percent-25-8.svg
+++ b/docs/assets/benchmark-deltas/gain-percent-25-8.svg
@@ -1,7 +1,7 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="68" height="20" viewBox="0 0 68 20" role="img" aria-label="(+11.3)">
+<svg xmlns="http://www.w3.org/2000/svg" width="68" height="20" viewBox="0 0 68 20" role="img" aria-label="(+25.8)">
   <style>
     text { fill: #7c3aed; font: 700 14px Inter, ui-sans-serif, system-ui, sans-serif; }
     @media (prefers-color-scheme: dark) { text { fill: #a78bfa; } }
   </style>
-  <text x="34" y="18" text-anchor="middle">(+11.3)</text>
+  <text x="34" y="18" text-anchor="middle">(+25.8)</text>
 </svg>

--- a/docs/assets/benchmark-deltas/gain-percent-29-9.svg
+++ b/docs/assets/benchmark-deltas/gain-percent-29-9.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="68" height="20" viewBox="0 0 68 20" role="img" aria-label="(+29.9)">
+  <style>
+    text { fill: #7c3aed; font: 700 14px Inter, ui-sans-serif, system-ui, sans-serif; }
+    @media (prefers-color-scheme: dark) { text { fill: #a78bfa; } }
+  </style>
+  <text x="34" y="18" text-anchor="middle">(+29.9)</text>
+</svg>

--- a/docs/assets/benchmark-results-rsihub-v2.svg
+++ b/docs/assets/benchmark-results-rsihub-v2.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1600" height="790" viewBox="0 0 1600 790" role="img" aria-labelledby="title desc">
 <title id="title">RSIHub benchmark results</title>
-<desc id="desc">Full-benchmark scores on Terminal Bench 2 and Tau cubed Banking for four evolution methods with MiniSWE and Codex target agents. MiniSWE is grouped left and Codex right in each panel. The vertical axes use truncated ranges (50–80% and 5–45%). Dark bar sections show seed scores above each axis baseline; light sections show improvement to the evolved score.</desc>
+<desc id="desc">Full-benchmark scores on Terminal Bench 2 and Tau cubed Banking for four evolution methods with MiniSWE and Codex target agents. MiniSWE is grouped left and Codex right in each panel. The vertical axes use truncated ranges (50–80% and 2–45%). Dark bar sections show seed scores above each axis baseline; light sections show improvement to the evolved score.</desc>
 <rect width="1600" height="790" rx="18" fill="#F2FBF7"/>
 <style>text{font-family:Inter,ui-sans-serif,system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}.title{font-size:25px;font-weight:750;fill:#19785A}.axis{font-size:12px;fill:#608675}.method{font-size:16px;font-weight:750;fill:#607169}.seed{font-size:16px;font-weight:800;fill:#FFFFFF}.best{font-size:16px;font-weight:800;fill:#19785A}.delta-up{fill:#7C3AED}.delta-down{fill:#CF222E}.delta-flat{fill:#9A6700}.agent{font-size:17px;font-weight:800}.legend{font-size:13px;font-weight:650;fill:#607169}.note{font-size:12px;fill:#608675}</style>
 <text class="title" x="427.5" y="72" text-anchor="middle">Terminal Bench 2</text>
@@ -23,107 +23,109 @@
 <text class="agent" x="240.8" y="101" text-anchor="middle" fill="#19785A">MiniSWE</text>
 <defs><clipPath id="b-0-0-0"><rect x="83.7" y="491.2" width="58" height="98.8" rx="5"/></clipPath></defs>
 <g clip-path="url(#b-0-0-0)"><rect x="83.7" y="491.2" width="58" height="17.5" fill="#65CE9F"/><rect x="83.7" y="508.7" width="58" height="81.3" fill="#19785A"/></g>
-<text class="seed" x="112.7" y="527.7" text-anchor="middle">55.1</text>
+<text class="seed" style="fill:#FFFFFF" x="112.7" y="527.7" text-anchor="middle">55.1</text>
 <text class="best" x="112.7" y="468.2" text-anchor="middle"><tspan x="112.7">56.2</tspan><tspan class="delta-up" x="112.7" dy="17">(+1.1)</tspan></text>
 <text class="method" x="112.7" y="608" text-anchor="end" transform="rotate(-45 112.7 608)">AHE</text>
 <defs><clipPath id="b-0-0-1"><rect x="169.1" y="295.2" width="58" height="294.8" rx="5"/></clipPath></defs>
 <g clip-path="url(#b-0-0-1)"><rect x="169.1" y="295.2" width="58" height="213.5" fill="#65CE9F"/><rect x="169.1" y="508.7" width="58" height="81.3" fill="#19785A"/></g>
-<text class="seed" x="198.1" y="527.7" text-anchor="middle">55.1</text>
+<text class="seed" style="fill:#FFFFFF" x="198.1" y="527.7" text-anchor="middle">55.1</text>
 <text class="best" x="198.1" y="272.2" text-anchor="middle"><tspan x="198.1">68.5</tspan><tspan class="delta-up" x="198.1" dy="17">(+13.4)</tspan></text>
 <text class="method" x="198.1" y="608" text-anchor="end" transform="rotate(-45 198.1 608)">Hyperagents</text>
 <defs><clipPath id="b-0-0-2"><rect x="254.4" y="347.8" width="58" height="242.2" rx="5"/></clipPath></defs>
 <g clip-path="url(#b-0-0-2)"><rect x="254.4" y="347.8" width="58" height="160.9" fill="#65CE9F"/><rect x="254.4" y="508.7" width="58" height="81.3" fill="#19785A"/></g>
-<text class="seed" x="283.4" y="527.7" text-anchor="middle">55.1</text>
+<text class="seed" style="fill:#FFFFFF" x="283.4" y="527.7" text-anchor="middle">55.1</text>
 <text class="best" x="283.4" y="324.8" text-anchor="middle"><tspan x="283.4">65.2</tspan><tspan class="delta-up" x="283.4" dy="17">(+10.1)</tspan></text>
 <text class="method" x="283.4" y="608" text-anchor="end" transform="rotate(-45 283.4 608)">A-Evolve</text>
 <defs><clipPath id="b-0-0-3"><rect x="339.8" y="437.0" width="58" height="153.0" rx="5"/></clipPath></defs>
 <g clip-path="url(#b-0-0-3)"><rect x="339.8" y="437.0" width="58" height="71.7" fill="#65CE9F"/><rect x="339.8" y="508.7" width="58" height="81.3" fill="#19785A"/></g>
-<text class="seed" x="368.8" y="527.7" text-anchor="middle">55.1</text>
+<text class="seed" style="fill:#FFFFFF" x="368.8" y="527.7" text-anchor="middle">55.1</text>
 <text class="best" x="368.8" y="414.0" text-anchor="middle"><tspan x="368.8">59.6</tspan><tspan class="delta-up" x="368.8" dy="17">(+4.5)</tspan></text>
 <text class="method" x="368.8" y="608" text-anchor="end" transform="rotate(-45 368.8 608)">GEPA</text>
 <text class="agent" x="614.2" y="101" text-anchor="middle" fill="#608675">Codex</text>
 <defs><clipPath id="b-0-1-0"><rect x="457.2" y="241.1" width="58" height="348.9" rx="5"/></clipPath></defs>
 <g clip-path="url(#b-0-1-0)"><rect x="457.2" y="241.1" width="58" height="35.1" fill="#B8D8C9"/><rect x="457.2" y="276.1" width="58" height="313.9" fill="#608675"/></g>
-<text class="seed" x="486.2" y="295.1" text-anchor="middle">69.7</text>
+<text class="seed" style="fill:#FFFFFF" x="486.2" y="295.1" text-anchor="middle">69.7</text>
 <text class="best" x="486.2" y="218.1" text-anchor="middle"><tspan x="486.2">71.9</tspan><tspan class="delta-up" x="486.2" dy="17">(+2.2)</tspan></text>
 <text class="method" x="486.2" y="608" text-anchor="end" transform="rotate(-45 486.2 608)">AHE</text>
 <defs><clipPath id="b-0-1-1"><rect x="542.6" y="258.6" width="58" height="331.4" rx="5"/></clipPath></defs>
 <g clip-path="url(#b-0-1-1)"><rect x="542.6" y="258.6" width="58" height="17.5" fill="#B8D8C9"/><rect x="542.6" y="276.1" width="58" height="313.9" fill="#608675"/></g>
-<text class="seed" x="571.6" y="295.1" text-anchor="middle">69.7</text>
+<text class="seed" style="fill:#FFFFFF" x="571.6" y="295.1" text-anchor="middle">69.7</text>
 <text class="best" x="571.6" y="235.6" text-anchor="middle"><tspan x="571.6">70.8</tspan><tspan class="delta-up" x="571.6" dy="17">(+1.1)</tspan></text>
 <text class="method" x="571.6" y="608" text-anchor="end" transform="rotate(-45 571.6 608)">Hyperagents</text>
 <defs><clipPath id="b-0-1-2"><rect x="627.9" y="258.6" width="58" height="331.4" rx="5"/></clipPath></defs>
 <g clip-path="url(#b-0-1-2)"><rect x="627.9" y="258.6" width="58" height="17.5" fill="#B8D8C9"/><rect x="627.9" y="276.1" width="58" height="313.9" fill="#608675"/></g>
-<text class="seed" x="656.9" y="295.1" text-anchor="middle">69.7</text>
+<text class="seed" style="fill:#FFFFFF" x="656.9" y="295.1" text-anchor="middle">69.7</text>
 <text class="best" x="656.9" y="235.6" text-anchor="middle"><tspan x="656.9">70.8</tspan><tspan class="delta-up" x="656.9" dy="17">(+1.1)</tspan></text>
 <text class="method" x="656.9" y="608" text-anchor="end" transform="rotate(-45 656.9 608)">A-Evolve</text>
 <defs><clipPath id="b-0-1-3"><rect x="713.3" y="276.1" width="58" height="313.9" rx="5"/></clipPath></defs>
 <g clip-path="url(#b-0-1-3)"><rect x="713.3" y="276.1" width="58" height="0.0" fill="#B8D8C9"/><rect x="713.3" y="276.1" width="58" height="313.9" fill="#608675"/></g>
-<text class="seed" x="742.3" y="295.1" text-anchor="middle">69.7</text>
+<text class="seed" style="fill:#FFFFFF" x="742.3" y="295.1" text-anchor="middle">69.7</text>
 <text class="best" x="742.3" y="253.1" text-anchor="middle"><tspan x="742.3">69.7</tspan><tspan class="delta-flat" x="742.3" dy="17">(0.0)</tspan></text>
 <text class="method" x="742.3" y="608" text-anchor="end" transform="rotate(-45 742.3 608)">GEPA</text>
 <text class="title" x="1212.5" y="72" text-anchor="middle">Tau³ Banking</text>
 <line x1="855.0" y1="590.0" x2="1570.0" y2="590.0" stroke="#D8EBE2"/>
-<text class="axis" x="845.0" y="594.0" text-anchor="end">5%</text>
-<line x1="855.0" y1="530.2" x2="1570.0" y2="530.2" stroke="#D8EBE2"/>
-<text class="axis" x="845.0" y="534.2" text-anchor="end">10%</text>
-<line x1="855.0" y1="470.5" x2="1570.0" y2="470.5" stroke="#D8EBE2"/>
-<text class="axis" x="845.0" y="474.5" text-anchor="end">15%</text>
-<line x1="855.0" y1="410.8" x2="1570.0" y2="410.8" stroke="#D8EBE2"/>
-<text class="axis" x="845.0" y="414.8" text-anchor="end">20%</text>
-<line x1="855.0" y1="351.0" x2="1570.0" y2="351.0" stroke="#D8EBE2"/>
-<text class="axis" x="845.0" y="355.0" text-anchor="end">25%</text>
-<line x1="855.0" y1="291.2" x2="1570.0" y2="291.2" stroke="#D8EBE2"/>
-<text class="axis" x="845.0" y="295.2" text-anchor="end">30%</text>
-<line x1="855.0" y1="231.5" x2="1570.0" y2="231.5" stroke="#D8EBE2"/>
-<text class="axis" x="845.0" y="235.5" text-anchor="end">35%</text>
-<line x1="855.0" y1="171.8" x2="1570.0" y2="171.8" stroke="#D8EBE2"/>
-<text class="axis" x="845.0" y="175.8" text-anchor="end">40%</text>
+<text class="axis" x="845.0" y="594.0" text-anchor="end">2%</text>
+<line x1="855.0" y1="556.7" x2="1570.0" y2="556.7" stroke="#D8EBE2"/>
+<text class="axis" x="845.0" y="560.7" text-anchor="end">5%</text>
+<line x1="855.0" y1="501.1" x2="1570.0" y2="501.1" stroke="#D8EBE2"/>
+<text class="axis" x="845.0" y="505.1" text-anchor="end">10%</text>
+<line x1="855.0" y1="445.5" x2="1570.0" y2="445.5" stroke="#D8EBE2"/>
+<text class="axis" x="845.0" y="449.5" text-anchor="end">15%</text>
+<line x1="855.0" y1="389.9" x2="1570.0" y2="389.9" stroke="#D8EBE2"/>
+<text class="axis" x="845.0" y="393.9" text-anchor="end">20%</text>
+<line x1="855.0" y1="334.3" x2="1570.0" y2="334.3" stroke="#D8EBE2"/>
+<text class="axis" x="845.0" y="338.3" text-anchor="end">25%</text>
+<line x1="855.0" y1="278.7" x2="1570.0" y2="278.7" stroke="#D8EBE2"/>
+<text class="axis" x="845.0" y="282.7" text-anchor="end">30%</text>
+<line x1="855.0" y1="223.2" x2="1570.0" y2="223.2" stroke="#D8EBE2"/>
+<text class="axis" x="845.0" y="227.2" text-anchor="end">35%</text>
+<line x1="855.0" y1="167.6" x2="1570.0" y2="167.6" stroke="#D8EBE2"/>
+<text class="axis" x="845.0" y="171.6" text-anchor="end">40%</text>
 <line x1="855.0" y1="112.0" x2="1570.0" y2="112.0" stroke="#D8EBE2"/>
 <text class="axis" x="845.0" y="116.0" text-anchor="end">45%</text>
 <line x1="855.0" y1="590" x2="1570.0" y2="590" stroke="#608675" stroke-width="1.2"/>
 <line x1="1212.5" y1="112" x2="1212.5" y2="637" stroke="#B7D0C4" stroke-dasharray="4 6"/>
 <text class="agent" x="1025.8" y="101" text-anchor="middle" fill="#19785A">MiniSWE</text>
-<defs><clipPath id="b-1-0-0"><rect x="868.7" y="255.4" width="58" height="334.6" rx="5"/></clipPath></defs>
-<g clip-path="url(#b-1-0-0)"><rect x="868.7" y="255.4" width="58" height="246.2" fill="#65CE9F"/><rect x="868.7" y="501.6" width="58" height="88.4" fill="#19785A"/></g>
-<text class="seed" x="897.7" y="520.6" text-anchor="middle">12.4</text>
-<text class="best" x="897.7" y="232.4" text-anchor="middle"><tspan x="897.7">33.0</tspan><tspan class="delta-up" x="897.7" dy="17">(+20.6)</tspan></text>
+<defs><clipPath id="b-1-0-0"><rect x="868.7" y="245.4" width="58" height="344.6" rx="5"/></clipPath></defs>
+<g clip-path="url(#b-1-0-0)"><rect x="868.7" y="245.4" width="58" height="332.4" fill="#65CE9F"/><rect x="868.7" y="577.8" width="58" height="12.2" fill="#19785A"/></g>
+<text class="seed" style="fill:#19785A" x="897.7" y="572.8" text-anchor="middle">3.1</text>
+<text class="best" x="897.7" y="222.4" text-anchor="middle"><tspan x="897.7">33.0</tspan><tspan class="delta-up" x="897.7" dy="17">(+29.9)</tspan></text>
 <text class="method" x="897.7" y="608" text-anchor="end" transform="rotate(-45 897.7 608)">AHE</text>
-<defs><clipPath id="b-1-0-1"><rect x="954.1" y="304.4" width="58" height="285.6" rx="5"/></clipPath></defs>
-<g clip-path="url(#b-1-0-1)"><rect x="954.1" y="304.4" width="58" height="197.2" fill="#65CE9F"/><rect x="954.1" y="501.6" width="58" height="88.4" fill="#19785A"/></g>
-<text class="seed" x="983.1" y="520.6" text-anchor="middle">12.4</text>
-<text class="best" x="983.1" y="281.4" text-anchor="middle"><tspan x="983.1">28.9</tspan><tspan class="delta-up" x="983.1" dy="17">(+16.5)</tspan></text>
+<defs><clipPath id="b-1-0-1"><rect x="954.1" y="291.0" width="58" height="299.0" rx="5"/></clipPath></defs>
+<g clip-path="url(#b-1-0-1)"><rect x="954.1" y="291.0" width="58" height="286.8" fill="#65CE9F"/><rect x="954.1" y="577.8" width="58" height="12.2" fill="#19785A"/></g>
+<text class="seed" style="fill:#19785A" x="983.1" y="572.8" text-anchor="middle">3.1</text>
+<text class="best" x="983.1" y="268.0" text-anchor="middle"><tspan x="983.1">28.9</tspan><tspan class="delta-up" x="983.1" dy="17">(+25.8)</tspan></text>
 <text class="method" x="983.1" y="608" text-anchor="end" transform="rotate(-45 983.1 608)">Hyperagents</text>
-<defs><clipPath id="b-1-0-2"><rect x="1039.4" y="390.4" width="58" height="199.6" rx="5"/></clipPath></defs>
-<g clip-path="url(#b-1-0-2)"><rect x="1039.4" y="390.4" width="58" height="111.1" fill="#65CE9F"/><rect x="1039.4" y="501.6" width="58" height="88.4" fill="#19785A"/></g>
-<text class="seed" x="1068.4" y="520.6" text-anchor="middle">12.4</text>
-<text class="best" x="1068.4" y="367.4" text-anchor="middle"><tspan x="1068.4">21.7</tspan><tspan class="delta-up" x="1068.4" dy="17">(+9.3)</tspan></text>
+<defs><clipPath id="b-1-0-2"><rect x="1039.4" y="371.0" width="58" height="219.0" rx="5"/></clipPath></defs>
+<g clip-path="url(#b-1-0-2)"><rect x="1039.4" y="371.0" width="58" height="206.8" fill="#65CE9F"/><rect x="1039.4" y="577.8" width="58" height="12.2" fill="#19785A"/></g>
+<text class="seed" style="fill:#19785A" x="1068.4" y="572.8" text-anchor="middle">3.1</text>
+<text class="best" x="1068.4" y="348.0" text-anchor="middle"><tspan x="1068.4">21.7</tspan><tspan class="delta-up" x="1068.4" dy="17">(+18.6)</tspan></text>
 <text class="method" x="1068.4" y="608" text-anchor="end" transform="rotate(-45 1068.4 608)">A-Evolve</text>
-<defs><clipPath id="b-1-0-3"><rect x="1124.8" y="366.5" width="58" height="223.5" rx="5"/></clipPath></defs>
-<g clip-path="url(#b-1-0-3)"><rect x="1124.8" y="366.5" width="58" height="135.0" fill="#65CE9F"/><rect x="1124.8" y="501.6" width="58" height="88.4" fill="#19785A"/></g>
-<text class="seed" x="1153.8" y="520.6" text-anchor="middle">12.4</text>
-<text class="best" x="1153.8" y="343.5" text-anchor="middle"><tspan x="1153.8">23.7</tspan><tspan class="delta-up" x="1153.8" dy="17">(+11.3)</tspan></text>
+<defs><clipPath id="b-1-0-3"><rect x="1124.8" y="348.8" width="58" height="241.2" rx="5"/></clipPath></defs>
+<g clip-path="url(#b-1-0-3)"><rect x="1124.8" y="348.8" width="58" height="229.0" fill="#65CE9F"/><rect x="1124.8" y="577.8" width="58" height="12.2" fill="#19785A"/></g>
+<text class="seed" style="fill:#19785A" x="1153.8" y="572.8" text-anchor="middle">3.1</text>
+<text class="best" x="1153.8" y="325.8" text-anchor="middle"><tspan x="1153.8">23.7</tspan><tspan class="delta-up" x="1153.8" dy="17">(+20.6)</tspan></text>
 <text class="method" x="1153.8" y="608" text-anchor="end" transform="rotate(-45 1153.8 608)">GEPA</text>
 <text class="agent" x="1399.2" y="101" text-anchor="middle" fill="#608675">Codex</text>
-<defs><clipPath id="b-1-1-0"><rect x="1242.2" y="329.5" width="58" height="260.5" rx="5"/></clipPath></defs>
-<g clip-path="url(#b-1-1-0)"><rect x="1242.2" y="329.5" width="58" height="25.1" fill="#B8D8C9"/><rect x="1242.2" y="354.6" width="58" height="235.4" fill="#608675"/></g>
-<text class="seed" x="1271.2" y="373.6" text-anchor="middle">24.7</text>
-<text class="best" x="1271.2" y="306.5" text-anchor="middle"><tspan x="1271.2">26.8</tspan><tspan class="delta-up" x="1271.2" dy="17">(+2.1)</tspan></text>
+<defs><clipPath id="b-1-1-0"><rect x="1242.2" y="314.3" width="58" height="275.7" rx="5"/></clipPath></defs>
+<g clip-path="url(#b-1-1-0)"><rect x="1242.2" y="314.3" width="58" height="23.3" fill="#B8D8C9"/><rect x="1242.2" y="337.7" width="58" height="252.3" fill="#608675"/></g>
+<text class="seed" style="fill:#FFFFFF" x="1271.2" y="356.7" text-anchor="middle">24.7</text>
+<text class="best" x="1271.2" y="291.3" text-anchor="middle"><tspan x="1271.2">26.8</tspan><tspan class="delta-up" x="1271.2" dy="17">(+2.1)</tspan></text>
 <text class="method" x="1271.2" y="608" text-anchor="end" transform="rotate(-45 1271.2 608)">AHE</text>
-<defs><clipPath id="b-1-1-1"><rect x="1327.6" y="181.3" width="58" height="408.7" rx="5"/></clipPath></defs>
-<g clip-path="url(#b-1-1-1)"><rect x="1327.6" y="181.3" width="58" height="173.3" fill="#B8D8C9"/><rect x="1327.6" y="354.6" width="58" height="235.4" fill="#608675"/></g>
-<text class="seed" x="1356.6" y="373.6" text-anchor="middle">24.7</text>
-<text class="best" x="1356.6" y="158.3" text-anchor="middle"><tspan x="1356.6">39.2</tspan><tspan class="delta-up" x="1356.6" dy="17">(+14.5)</tspan></text>
+<defs><clipPath id="b-1-1-1"><rect x="1327.6" y="176.5" width="58" height="413.5" rx="5"/></clipPath></defs>
+<g clip-path="url(#b-1-1-1)"><rect x="1327.6" y="176.5" width="58" height="161.2" fill="#B8D8C9"/><rect x="1327.6" y="337.7" width="58" height="252.3" fill="#608675"/></g>
+<text class="seed" style="fill:#FFFFFF" x="1356.6" y="356.7" text-anchor="middle">24.7</text>
+<text class="best" x="1356.6" y="153.5" text-anchor="middle"><tspan x="1356.6">39.2</tspan><tspan class="delta-up" x="1356.6" dy="17">(+14.5)</tspan></text>
 <text class="method" x="1356.6" y="608" text-anchor="end" transform="rotate(-45 1356.6 608)">Hyperagents</text>
-<defs><clipPath id="b-1-1-2"><rect x="1412.9" y="304.4" width="58" height="285.6" rx="5"/></clipPath></defs>
-<g clip-path="url(#b-1-1-2)"><rect x="1412.9" y="304.4" width="58" height="50.2" fill="#B8D8C9"/><rect x="1412.9" y="354.6" width="58" height="235.4" fill="#608675"/></g>
-<text class="seed" x="1441.9" y="373.6" text-anchor="middle">24.7</text>
-<text class="best" x="1441.9" y="281.4" text-anchor="middle"><tspan x="1441.9">28.9</tspan><tspan class="delta-up" x="1441.9" dy="17">(+4.2)</tspan></text>
+<defs><clipPath id="b-1-1-2"><rect x="1412.9" y="291.0" width="58" height="299.0" rx="5"/></clipPath></defs>
+<g clip-path="url(#b-1-1-2)"><rect x="1412.9" y="291.0" width="58" height="46.7" fill="#B8D8C9"/><rect x="1412.9" y="337.7" width="58" height="252.3" fill="#608675"/></g>
+<text class="seed" style="fill:#FFFFFF" x="1441.9" y="356.7" text-anchor="middle">24.7</text>
+<text class="best" x="1441.9" y="268.0" text-anchor="middle"><tspan x="1441.9">28.9</tspan><tspan class="delta-up" x="1441.9" dy="17">(+4.2)</tspan></text>
 <text class="method" x="1441.9" y="608" text-anchor="end" transform="rotate(-45 1441.9 608)">A-Evolve</text>
-<defs><clipPath id="b-1-1-3"><rect x="1498.3" y="255.4" width="58" height="334.6" rx="5"/></clipPath></defs>
-<g clip-path="url(#b-1-1-3)"><rect x="1498.3" y="255.4" width="58" height="99.2" fill="#B8D8C9"/><rect x="1498.3" y="354.6" width="58" height="235.4" fill="#608675"/></g>
-<text class="seed" x="1527.3" y="373.6" text-anchor="middle">24.7</text>
-<text class="best" x="1527.3" y="232.4" text-anchor="middle"><tspan x="1527.3">33.0</tspan><tspan class="delta-up" x="1527.3" dy="17">(+8.3)</tspan></text>
+<defs><clipPath id="b-1-1-3"><rect x="1498.3" y="245.4" width="58" height="344.6" rx="5"/></clipPath></defs>
+<g clip-path="url(#b-1-1-3)"><rect x="1498.3" y="245.4" width="58" height="92.3" fill="#B8D8C9"/><rect x="1498.3" y="337.7" width="58" height="252.3" fill="#608675"/></g>
+<text class="seed" style="fill:#FFFFFF" x="1527.3" y="356.7" text-anchor="middle">24.7</text>
+<text class="best" x="1527.3" y="222.4" text-anchor="middle"><tspan x="1527.3">33.0</tspan><tspan class="delta-up" x="1527.3" dy="17">(+8.3)</tspan></text>
 <text class="method" x="1527.3" y="608" text-anchor="end" transform="rotate(-45 1527.3 608)">GEPA</text>
 <defs><clipPath id="legend-0"><rect x="698" y="700" width="26" height="22" rx="5"/></clipPath></defs>
 <g clip-path="url(#legend-0)"><rect x="698" y="700" width="26" height="11" fill="#65CE9F"/><rect x="698" y="711" width="26" height="11" fill="#19785A"/></g>


### PR DESCRIPTION
## Summary

- correct the MiniSWE Tau³ Banking full-benchmark seed score from 12.4% to 3.1%
- recompute the four affected improvements as +29.9, +25.8, +18.6, and +20.6 percentage points
- update the benchmark chart and use a 2–45% truncated Tau³ axis so the 3.1% seed remains visible without returning the chart to a zero baseline
- replace the superseded delta-label assets

## Impact

The README table and benchmark chart now consistently reflect the corrected Tau³ Banking MiniSWE baseline while retaining the train-first table layout.

## Validation

- validated all 16 table rows against the supplied train/full-benchmark values
- validated every local README image reference
- parsed and checked the SVG XML, plotted values, deltas, and axis range
- `git diff --check`
