### PR TITLE
Add Tau3 Banking MCP CLI hint to MiniSWE

### DIFF
--- a/src/evolve/integrations/harbor/miniswe_candidate.py
+++ b/src/evolve/integrations/harbor/miniswe_candidate.py
@@ -19,6 +19,12 @@ LOG_PATH = "/logs/agent/mini-swe-agent.txt"
 RUNTIME_EVIDENCE_PATH = "/logs/agent/evolve-runtime.json"
 HOST_UV_PATH = "/tmp/evolve-uv"
 SOURCE_ARCHIVE_PATH = "/tmp/evolve-miniswe-source.tar"
+TAU3_MCP_CLI_PATH = "/tmp/tau3-mcp.py"
+TAU3_BANKING_MCP_CLI_HINT = (
+    "Use the Bash tool to access the `tau3-runtime` MCP tools through "
+    f"`{TAU3_MCP_CLI_PATH}`: run `{VENV_PYTHON} {TAU3_MCP_CLI_PATH} list` to list tools "
+    f"and `{VENV_PYTHON} {TAU3_MCP_CLI_PATH} call TOOL_NAME 'JSON_ARGUMENTS'` to call one."
+)
 PROXY_ENV_NAMES = ("HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY", "http_proxy", "https_proxy", "no_proxy")
 
 
@@ -458,7 +464,13 @@ class CandidateMiniSweAgent(MiniSweAgent):
                 mcp_info += f"- {server.name}: stdio transport, command: {server.command} {' '.join(server.args)}\n"
             else:
                 mcp_info += f"- {server.name}: {server.transport} transport, url: {server.url}\n"
+        if self._is_tau3_banking_task() and any(server.name == "tau3-runtime" for server in self.mcp_servers):
+            mcp_info += f"\n{TAU3_BANKING_MCP_CLI_HINT}\n"
         return instruction + mcp_info
+
+    def _is_tau3_banking_task(self) -> bool:
+        task_trial_name = self.logs_dir.parent.name
+        return task_trial_name.split("__", 1)[0].startswith("tau3-banking_")
 
     def _run_command(self, task: str) -> str:
         task_literal = repr(task)

--- a/tests/test_miniswe_harbor_wrapper.py
+++ b/tests/test_miniswe_harbor_wrapper.py
@@ -629,6 +629,44 @@ def test_miniswe_wrapper_runs_candidate_source_api_not_cli(tmp_path: Path, monke
     assert 'env_kwargs["cwd"] = os.environ.get("MINISWE_CWD") or os.getcwd()' in module.RUNNER
 
 
+@pytest.mark.parametrize(
+    ("trial_name", "expects_hint"),
+    [
+        ("tau3-banking_knowledge-task-067__trial", True),
+        ("tau3-airline_knowledge-task-067__trial", False),
+        ("terminal-bench-task__trial", False),
+    ],
+)
+def test_miniswe_wrapper_only_adds_tau3_cli_hint_for_banking_tasks(
+    adapter_path: Path,
+    monkeypatch,
+    tmp_path: Path,
+    trial_name: str,
+    expects_hint: bool,
+) -> None:
+    _install_fake_harbor(monkeypatch)
+    module = _load(adapter_path)
+    agent = module.MiniSweSourceAgent()
+    agent.logs_dir = tmp_path / trial_name / "agent"
+    agent.mcp_servers = [
+        types.SimpleNamespace(
+            name="tau3-runtime",
+            transport="streamable-http",
+            url="http://tau3-runtime:8000/mcp",
+        )
+    ]
+
+    augmented = agent._augment_instruction("Original instruction.")
+    generic = (
+        "Original instruction.\n\nMCP Servers:\n"
+        "The following MCP servers are available for this task.\n"
+        "- tau3-runtime: streamable-http transport, url: http://tau3-runtime:8000/mcp\n"
+    )
+
+    assert (module.TAU3_BANKING_MCP_CLI_HINT in augmented) is expects_hint
+    assert augmented == (f"{generic}\n{module.TAU3_BANKING_MCP_CLI_HINT}\n" if expects_hint else generic)
+
+
 def test_miniswe_runtime_and_offline_install_forward_download_proxies(tmp_path: Path, monkeypatch) -> None:
     _install_fake_harbor(monkeypatch)
     proxy_names = ("HTTP_PROXY", "HTTPS_PROXY", "http_proxy", "https_proxy")


### PR DESCRIPTION
## Summary

- add the `tau3-mcp.py` Bash invocation hint to the framework-owned MiniSWE candidate adapter
- gate the hint on a Tau3 Banking task name and the presence of the `tau3-runtime` MCP server
- preserve the existing instruction augmentation for Tau3 Airline and non-Tau3 benchmarks

## Why

MiniSWE cannot consume the Tau3 MCP server natively in the same way as Codex. Tau3 Banking tasks provide a `/tmp/tau3-mcp.py` shell entrypoint, so the target needs a concise instruction explaining how to list and call tools. This must remain benchmark-specific so other evaluators receive their original prompt unchanged.

## Validation

- `uv run --frozen pytest -q tests/test_miniswe_harbor_wrapper.py` — 36 passed
- `uv run --frozen ruff check .`
- `uv run --frozen ruff format --check .`
- `uv run --frozen ty check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added guidance for using the Tau3 command-line interface during applicable banking tasks.
  * Guidance is automatically included when the relevant MCP server is available.

* **Bug Fixes**
  * Ensured Tau3 guidance appears only for banking tasks and does not affect airline or terminal-bench tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->