### PR TITLE
style(viewer): polish evolution tree scrolling

### DIFF
--- a/src/evolve/viewer/static/catalog.css
+++ b/src/evolve/viewer/static/catalog.css
@@ -109,8 +109,8 @@ button:focus-visible, input:focus-visible, a:focus-visible { outline: 3px solid 
 .score-arrow { padding-bottom: 4px; color: var(--line-strong); font-size: 17px; }
 .score-delta { align-self: center; padding: 5px 7px; color: #126842; background: var(--accent-soft); border-radius: 7px; font-size: 10px; font-weight: 700; }
 .score-delta.negative { color: var(--danger); background: var(--danger-soft); }
-.lineage-box { position: relative; padding: 10px; overflow: auto; background: #f8faf9; border: 1px solid #dce4e0; border-radius: 14px; box-shadow: inset 0 1px 0 rgb(255 255 255 / 80%), 0 6px 18px rgb(31 55 45 / 5%); }
-.lineage-box svg { display: block; width: max(100%, var(--lineage-width)); min-width: var(--lineage-width); height: var(--lineage-height); overflow: visible; }
+.lineage-box { position: relative; max-height: min(280px, 45vh); padding: 10px; overflow: auto; overscroll-behavior: contain; scrollbar-gutter: stable; touch-action: pan-x pan-y; background: #f8faf9; border: 1px solid #dce4e0; border-radius: 14px; box-shadow: inset 0 1px 0 rgb(255 255 255 / 80%), 0 6px 18px rgb(31 55 45 / 5%); }
+.lineage-box svg { display: block; width: var(--lineage-width); min-width: var(--lineage-width); max-width: none; height: var(--lineage-height); min-height: var(--lineage-height); overflow: visible; }
 .lineage-edge { fill: none; stroke: #96c8ba; stroke-width: 1.45; vector-effect: non-scaling-stroke; }
 .lineage-edge.champion-path { stroke: #58a992; stroke-width: 2; }
 .lineage-node rect { fill: #fff; stroke: #16856f; stroke-width: 1.7; vector-effect: non-scaling-stroke; }

--- a/src/evolve/viewer/static/catalog.css
+++ b/src/evolve/viewer/static/catalog.css
@@ -109,8 +109,11 @@ button:focus-visible, input:focus-visible, a:focus-visible { outline: 3px solid 
 .score-arrow { padding-bottom: 4px; color: var(--line-strong); font-size: 17px; }
 .score-delta { align-self: center; padding: 5px 7px; color: #126842; background: var(--accent-soft); border-radius: 7px; font-size: 10px; font-weight: 700; }
 .score-delta.negative { color: var(--danger); background: var(--danger-soft); }
-.lineage-box { position: relative; max-height: min(280px, 45vh); padding: 10px; overflow: auto; overscroll-behavior: contain; scrollbar-gutter: stable; touch-action: pan-x pan-y; background: #f8faf9; border: 1px solid #dce4e0; border-radius: 14px; box-shadow: inset 0 1px 0 rgb(255 255 255 / 80%), 0 6px 18px rgb(31 55 45 / 5%); }
+.lineage-box { position: relative; max-height: min(360px, 58vh); padding: 10px; overflow: auto; overscroll-behavior: contain; scrollbar-color: #b8c8c1 transparent; scrollbar-width: thin; touch-action: pan-x pan-y; background: #fafcfb; border: 1px solid #e2e9e5; border-radius: 14px; }
 .lineage-box svg { display: block; width: var(--lineage-width); min-width: var(--lineage-width); max-width: none; height: var(--lineage-height); min-height: var(--lineage-height); overflow: visible; }
+.lineage-box::-webkit-scrollbar { width: 8px; height: 8px; }
+.lineage-box::-webkit-scrollbar-track, .lineage-box::-webkit-scrollbar-corner { background: transparent; }
+.lineage-box::-webkit-scrollbar-thumb { background: #b8c8c1; background-clip: padding-box; border: 2px solid transparent; border-radius: 999px; }
 .lineage-edge { fill: none; stroke: #96c8ba; stroke-width: 1.45; vector-effect: non-scaling-stroke; }
 .lineage-edge.champion-path { stroke: #58a992; stroke-width: 2; }
 .lineage-node rect { fill: #fff; stroke: #16856f; stroke-width: 1.7; vector-effect: non-scaling-stroke; }

--- a/src/evolve/viewer/static/styles.css
+++ b/src/evolve/viewer/static/styles.css
@@ -130,8 +130,8 @@ main.diff-mode { width: min(var(--diff-content-max), 100%); }
 .champion-diff-actions span { color: var(--muted); font-size: 9px; }
 .evolution-lineage-card { padding-bottom: 15px; }
 .evolution-lineage-card .card-header { margin-bottom: 13px; }
-.lineage-box { position: relative; padding: 13px; overflow: auto; background: #f8faf9; border: 1px solid #dce4e0; border-radius: 16px; box-shadow: inset 0 1px 0 rgb(255 255 255 / 80%), 0 7px 20px rgb(31 55 45 / 5%); }
-.lineage-box svg { display: block; width: max(100%, var(--lineage-width)); min-width: var(--lineage-width); height: var(--lineage-height); overflow: visible; }
+.lineage-box { position: relative; max-height: min(380px, 55vh); padding: 13px; overflow: auto; overscroll-behavior: contain; scrollbar-gutter: stable; touch-action: pan-x pan-y; background: #f8faf9; border: 1px solid #dce4e0; border-radius: 16px; box-shadow: inset 0 1px 0 rgb(255 255 255 / 80%), 0 7px 20px rgb(31 55 45 / 5%); }
+.lineage-box svg { display: block; width: var(--lineage-width); min-width: var(--lineage-width); max-width: none; height: var(--lineage-height); min-height: var(--lineage-height); overflow: visible; }
 .lineage-edge { fill: none; stroke: #96c8ba; stroke-width: 1.45; vector-effect: non-scaling-stroke; }
 .lineage-edge.champion-path { stroke: #58a992; stroke-width: 2; }
 .lineage-node rect { fill: #fff; stroke: #16856f; stroke-width: 1.7; vector-effect: non-scaling-stroke; }

--- a/src/evolve/viewer/static/styles.css
+++ b/src/evolve/viewer/static/styles.css
@@ -130,8 +130,11 @@ main.diff-mode { width: min(var(--diff-content-max), 100%); }
 .champion-diff-actions span { color: var(--muted); font-size: 9px; }
 .evolution-lineage-card { padding-bottom: 15px; }
 .evolution-lineage-card .card-header { margin-bottom: 13px; }
-.lineage-box { position: relative; max-height: min(380px, 55vh); padding: 13px; overflow: auto; overscroll-behavior: contain; scrollbar-gutter: stable; touch-action: pan-x pan-y; background: #f8faf9; border: 1px solid #dce4e0; border-radius: 16px; box-shadow: inset 0 1px 0 rgb(255 255 255 / 80%), 0 7px 20px rgb(31 55 45 / 5%); }
+.lineage-box { position: relative; max-height: min(440px, 65vh); padding: 13px; overflow: auto; overscroll-behavior: contain; scrollbar-color: #b8c8c1 transparent; scrollbar-width: thin; touch-action: pan-x pan-y; background: #fafcfb; border: 1px solid #e2e9e5; border-radius: 16px; }
 .lineage-box svg { display: block; width: var(--lineage-width); min-width: var(--lineage-width); max-width: none; height: var(--lineage-height); min-height: var(--lineage-height); overflow: visible; }
+.lineage-box::-webkit-scrollbar { width: 8px; height: 8px; }
+.lineage-box::-webkit-scrollbar-track, .lineage-box::-webkit-scrollbar-corner { background: transparent; }
+.lineage-box::-webkit-scrollbar-thumb { background: #b8c8c1; background-clip: padding-box; border: 2px solid transparent; border-radius: 999px; }
 .lineage-edge { fill: none; stroke: #96c8ba; stroke-width: 1.45; vector-effect: non-scaling-stroke; }
 .lineage-edge.champion-path { stroke: #58a992; stroke-width: 2; }
 .lineage-node rect { fill: #fff; stroke: #16856f; stroke-width: 1.7; vector-effect: non-scaling-stroke; }


### PR DESCRIPTION
## Summary
- keep evolution tree node cards at fixed dimensions
- allow horizontal and vertical scrolling only when the lineage exceeds its viewport
- make scrollbars subtle and remove the visually separated gutter
- expand the viewport so common five-to-six-row trees remain uninterrupted

## Validation
- `node --test tests/frontend/viewer-ui.test.mjs`
- `.venv/bin/ruff check .`
- `.venv/bin/ruff format --check .`
- `.venv/bin/ty check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved lineage diagram scrolling on touch devices with constrained height and two-direction panning.
  * Added slimmer, customized scrollbars for better navigation.
  * Preserved the diagram’s intended dimensions instead of stretching it to fit the container.
  * Refined the lineage viewer’s background, borders, and shadows for a cleaner appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->