### PR TITLE
fix: align recipe agent settings with benchmark runs

### DIFF
--- a/recipes/README.md
+++ b/recipes/README.md
@@ -16,8 +16,8 @@ represents.
 - [HyperAgents for Codex](hyperagents_codex/README.md)
 
 All main recipes use the shared, content-pinned Terminal-Bench 2.0 subset. The
-setup script downloads and verifies it and builds only the selected recipe's
-pinned MiniSWE or Codex mutation-agent image:
+setup script downloads and verifies it and builds the pinned Codex 0.146.0
+mutation-agent image used by the benchmark recipes:
 
 ```bash
 ./scripts/setup_terminal_bench.sh gepa

--- a/recipes/aevolve/evolve.yaml
+++ b/recipes/aevolve/evolve.yaml
@@ -27,6 +27,7 @@ operators:
       model: gpt-5.4
       environment: docker
       image: evolve-mutate-codex:20260818-codex0146
+      agent_kwargs: {reasoning_effort: xhigh}
       editable_roots: [target]
       evolve_prompts: true
       evolve_skills: true

--- a/recipes/ahe/README.md
+++ b/recipes/ahe/README.md
@@ -9,10 +9,9 @@ debugger input, so its score
 and debugger evidence come from the same retained Harbor trajectories rather
 than a separate rollout run. Each task receives one required LLM debugger
 analysis using the same model and runner as the mutate operator. The debugger uses
-`high` reasoning so its short MiniSWE protocol reliably reaches the required
-tool call; the change-producing mutation agent also uses `high`. Both paths receive
-an explicit 64k output budget through Harbor's `max_tokens` constructor field
-because mini-swe-agent otherwise uses its 1,000-token default. Failures
+`high` reasoning and an explicit 64k output budget. The change-producing
+mutation agent is Codex CLI 0.146.0 with `xhigh` reasoning, matching the
+benchmark configuration used for the reported AHE runs. Failures
 stop the generation after three attempts; there is no silent deterministic
 fallback. This is configured as `debugger_max_retries: 2`: one initial
 debugger call plus at most two retries.
@@ -71,12 +70,13 @@ temporary limits for the canonical full analysis. The `mutate` stage is
 optional on this path and remains the mutation stage for `evolve run`.
 
 Live runs need Docker, Harbor, model credentials, and an immutable evaluator
-runtime. Build the small workspace image once before running:
+runtime. Build the pinned Codex mutation image once before running:
 
 ```bash
-IMAGE_CONTEXT="$(python -c 'from evolve.config import resource_root; print(resource_root("containers") / "mutate")')"
-docker build --build-arg MINISWE_VERSION=2.4.5 \
-  -t evolve-mutate-app:20260724-tools-mswe245 "$IMAGE_CONTEXT"
+IMAGE_CONTEXT="$(python -c 'from evolve.config import resource_root; print(resource_root("containers") / "mutate-codex")')"
+docker build --build-arg CODEX_VERSION=0.146.0 \
+  -t evolve-mutate-codex:20260818-codex0146 "$IMAGE_CONTEXT"
 ```
 
-The recipe never requires a local Codex command.
+Codex is preinstalled in the image; the recipe does not require a host Codex
+installation.

--- a/recipes/ahe/evolve.yaml
+++ b/recipes/ahe/evolve.yaml
@@ -17,7 +17,7 @@ operators:
   select: {operator: ahe_latest, timeout_s: 600, config: {}}
   rollout: {operator: parent_evaluation, timeout_s: 600, config: {field_limit: 2000}}
   analyze: {operator: ahe, timeout_s: 3600, config: {max_tasks: 30, max_concurrent: 10, timeout_per_task: 600, retry_attempts: 1, debugger_agent_kwargs: {reasoning_effort: high, max_tokens: 64000}, field_limit: 2000}}
-  mutate: {operator: ahe, timeout_s: 3600, config: {runner: harbor, expose_gate_data: false, agent: evolve.integrations.harbor.miniswe_task_file:InstalledMiniSweAgent, model: openai/gpt-5.4-2026-03-05, environment: docker, image: evolve-mutate-app:20260724-tools-mswe245, editable_roots: [target], prompt_path: target/src/minisweagent/config/mini.yaml, skills_dir: target/skills, memory_dir: target/memory, agent_kwargs: {reasoning_effort: high, cost_limit: 0, max_tokens: 64000}, max_retries: 1}}
+  mutate: {operator: ahe, timeout_s: 3600, config: {runner: harbor, expose_gate_data: false, agent: codex, model: gpt-5.4, environment: docker, image: evolve-mutate-codex:20260818-codex0146, editable_roots: [target], prompt_path: target/src/minisweagent/config/mini.yaml, skills_dir: target/skills, memory_dir: target/memory, agent_kwargs: {reasoning_effort: xhigh}, max_retries: 1}}
   gate: {operator: ahe_artifact_valid, timeout_s: 600, config: {}}
   record: {operator: jsonl, timeout_s: 600, config: {}}
   timeout_s: 600
@@ -42,5 +42,6 @@ evaluator:
   agent_env:
     MINISWE_STEP_LIMIT: "100"
     MINISWE_REASONING_EFFORT: "high"
-    MINISWE_COST_LIMIT: "0"
+    MINISWE_COST_LIMIT: "3.0"
+    MINISWE_MAX_OUTPUT_LIMIT: "10000"
     MINISWE_ENV_TIMEOUT: "30"

--- a/recipes/ahe_codex/evolve.yaml
+++ b/recipes/ahe_codex/evolve.yaml
@@ -15,7 +15,7 @@ operators:
   select: {operator: ahe_latest, timeout_s: 600, config: {}}
   rollout: {operator: parent_evaluation, timeout_s: 600, config: {field_limit: 2000}}
   analyze: {operator: ahe, timeout_s: 3600, config: {max_tasks: 30, max_concurrent: 5, timeout_per_task: 600, debugger_max_retries: 2, debugger_agent_kwargs: {reasoning_effort: high}, field_limit: 2000}}
-  mutate: {operator: ahe, timeout_s: 3600, config: {runner: harbor, expose_gate_data: false, agent: codex, model: gpt-5.4, environment: docker, image: evolve-mutate-codex:20260818-codex0146, editable_roots: [target], prompt_path: target/prompt.md, skills_dir: target/skills, agent_kwargs: {reasoning_effort: high}, max_retries: 1}}
+  mutate: {operator: ahe, timeout_s: 3600, config: {runner: harbor, expose_gate_data: false, agent: codex, model: gpt-5.4, environment: docker, image: evolve-mutate-codex:20260818-codex0146, editable_roots: [target], prompt_path: target/prompt.md, skills_dir: target/skills, agent_kwargs: {reasoning_effort: xhigh}, max_retries: 1}}
   gate: {operator: ahe_artifact_valid, timeout_s: 600, config: {}}
   record: {operator: jsonl, timeout_s: 600, config: {}}
   timeout_s: 600

--- a/recipes/gepa/evolve.yaml
+++ b/recipes/gepa/evolve.yaml
@@ -34,6 +34,7 @@ operators:
       model: gpt-5.4
       environment: docker
       image: evolve-mutate-codex:20260818-codex0146
+      agent_kwargs: {reasoning_effort: xhigh}
       editable_roots: [target]
       components:
         system_prompt: target/prompt.md

--- a/recipes/hill_climb/README.md
+++ b/recipes/hill_climb/README.md
@@ -13,6 +13,7 @@ population memory, but the population has only one active frontier.
 `rollout.operator: harbor` runs the current parent on the frozen train split.
 `analyze.operator: failure_patterns` distills verifier-grounded failures and passing behavior for `mutate`.
 `mutate.operator: hyperagents` applies the selected evidence; `config.runner: harbor` runs its editing agent in an isolated Harbor task.
+The editing agent is Codex CLI 0.146.0 with `xhigh` reasoning.
 `gate.operator: hillclimb` compares child and parent on the same task hash.
 `evaluator.engine: harbor` runs the canonical black-box benchmark.
 `sampling: static` keeps every recipe on the same frozen validation set.

--- a/recipes/hill_climb/evolve.yaml
+++ b/recipes/hill_climb/evolve.yaml
@@ -18,12 +18,13 @@ operators:
   select: {operator: greedy, config: {}}
   rollout: {operator: harbor, timeout_s: 3600, config: {budget_tasks: 32, n_concurrent: 16, agent_setup_timeout_multiplier: 1, max_retries: 1}}
   analyze: {operator: failure_patterns, timeout_s: 600, config: {max_chars: 30000}}
-  mutate: {operator: hyperagents, timeout_s: 3600, config: {runner: harbor, expose_gate_data: false, agent: codex, model: gpt-5.4, environment: docker, image: evolve-mutate-codex:20260818-codex0146, editable_roots: [target], prompt_path: target/src/minisweagent/config/mini.yaml, skills_dir: target/skills, memory_dir: target/memory, max_retries: 1}}
+  mutate: {operator: hyperagents, timeout_s: 3600, config: {runner: harbor, expose_gate_data: false, agent: codex, model: gpt-5.4, environment: docker, image: evolve-mutate-codex:20260818-codex0146, editable_roots: [target], prompt_path: target/src/minisweagent/config/mini.yaml, skills_dir: target/skills, memory_dir: target/memory, agent_kwargs: {reasoning_effort: xhigh}, max_retries: 1}}
   gate: {operator: hillclimb, config: {}}
   record: {operator: jsonl, config: {}}
   timeout_s: 600
 evaluator:
   engine: harbor
+  model: openai/gpt-5.4-2026-03-05
   runtime:
     candidate: {variant: uv, project: target, python: "3.12"}
   dataset: terminal-bench-2-30-v1
@@ -37,3 +38,9 @@ evaluator:
   max_retries: 1
   benchmark_timeout_is_zero: true
   partial_floor: 0.8
+  agent_env:
+    MINISWE_STEP_LIMIT: "100"
+    MINISWE_REASONING_EFFORT: "high"
+    MINISWE_COST_LIMIT: "3.0"
+    MINISWE_MAX_OUTPUT_LIMIT: "10000"
+    MINISWE_ENV_TIMEOUT: "30"

--- a/recipes/hill_climb_codex/README.md
+++ b/recipes/hill_climb_codex/README.md
@@ -4,3 +4,4 @@ This profile evolves the built-in Codex target's prompt and skills with the
 standard greedy selection and strict hill-climb gate. Candidate behavior is
 evaluated through Harbor on the shared pinned Terminal-Bench 2.0 subset. The mutation agent runs in the pinned
 Codex image documented in `recipes/README.md`.
+The mutation agent uses `xhigh` reasoning.

--- a/recipes/hill_climb_codex/evolve.yaml
+++ b/recipes/hill_climb_codex/evolve.yaml
@@ -16,7 +16,7 @@ operators:
   select: {operator: greedy, config: {}}
   rollout: {operator: harbor, timeout_s: 3600, config: {budget_tasks: 16, n_concurrent: 4, agent_setup_timeout_multiplier: 1, max_retries: 1}}
   analyze: {operator: failure_patterns, timeout_s: 600, config: {max_chars: 30000}}
-  mutate: {operator: hyperagents, timeout_s: 3600, config: {runner: harbor, expose_gate_data: false, agent: codex, model: gpt-5.4, environment: docker, image: evolve-mutate-codex:20260818-codex0146, editable_roots: [target], prompt_path: target/prompt.md, skills_dir: target/skills, memory_dir: target/memory, max_retries: 1}}
+  mutate: {operator: hyperagents, timeout_s: 3600, config: {runner: harbor, expose_gate_data: false, agent: codex, model: gpt-5.4, environment: docker, image: evolve-mutate-codex:20260818-codex0146, editable_roots: [target], prompt_path: target/prompt.md, skills_dir: target/skills, memory_dir: target/memory, agent_kwargs: {reasoning_effort: xhigh}, max_retries: 1}}
   gate: {operator: hillclimb, config: {}}
   record: {operator: jsonl, config: {}}
   timeout_s: 600

--- a/recipes/hyperagents/README.md
+++ b/recipes/hyperagents/README.md
@@ -16,10 +16,10 @@ workspace initialization generates and freezes it explicitly.
 `select.operator: score_child_prop` balances score with child-proposal behavior.
 `rollout.operator: parent_evaluation` exposes the selected parent's sanitized, certified gate evaluation without launching another task run.
 `analyze.operator: trace_browser` exposes current traces, metrics, and history through the normalized feedback bundle.
-`mutate.operator: hyperagents` consumes that bundle through Harbor's installed MiniSWE agent while retaining self-referential editing.
-The mutation agent uses `high` reasoning with an explicit 64k output budget.
-The explicit `max_tokens` value is required because mini-swe-agent otherwise
-uses its 1,000-token default.
+`mutate.operator: hyperagents` consumes that bundle through a Harbor-hosted
+Codex CLI 0.146.0 agent while retaining self-referential editing. The mutation
+agent uses `xhigh` reasoning, matching the benchmark configuration used for
+the reported HyperAgents runs.
 `gate.operator: parent_eligible` admits evaluated process candidates.
 `evaluator.engine: harbor` runs the canonical black-box benchmark.
 `task_scope: full` freezes all 30 curated task identities as one shared
@@ -40,9 +40,9 @@ Candidate execution uses Harbor's native task timeouts
 Build the workspace image once before running:
 
 ```bash
-IMAGE_CONTEXT="$(python -c 'from evolve.config import resource_root; print(resource_root("containers") / "mutate")')"
-docker build --build-arg MINISWE_VERSION=2.4.5 \
-  -t evolve-mutate-app:20260724-tools-mswe245 "$IMAGE_CONTEXT"
+IMAGE_CONTEXT="$(python -c 'from evolve.config import resource_root; print(resource_root("containers") / "mutate-codex")')"
+docker build --build-arg CODEX_VERSION=0.146.0 \
+  -t evolve-mutate-codex:20260818-codex0146 "$IMAGE_CONTEXT"
 ```
 
 ## Operator Routing

--- a/recipes/hyperagents/evolve.yaml
+++ b/recipes/hyperagents/evolve.yaml
@@ -18,7 +18,7 @@ operators:
   select: {operator: score_child_prop, config: {seed: 0}}
   rollout: {operator: parent_evaluation, timeout_s: 600, config: {field_limit: 2000}}
   analyze: {operator: trace_browser, timeout_s: 600, config: {max_chars: 30000}}
-  mutate: {operator: hyperagents, timeout_s: 21600, config: {runner: harbor, expose_gate_data: false, agent: evolve.integrations.harbor.miniswe_task_file:InstalledMiniSweAgent, model: openai/gpt-5.4-2026-03-05, environment: docker, image: evolve-mutate-app:20260724-tools-mswe245, editable_roots: [target, operators], prompt_path: target/src/minisweagent/config/mini.yaml, skills_dir: target/skills, memory_dir: target/memory, agent_kwargs: {reasoning_effort: high, cost_limit: 0, max_tokens: 64000}, max_retries: 1}}
+  mutate: {operator: hyperagents, timeout_s: 21600, config: {runner: harbor, expose_gate_data: false, agent: codex, model: gpt-5.4, environment: docker, image: evolve-mutate-codex:20260818-codex0146, editable_roots: [target, operators], prompt_path: target/src/minisweagent/config/mini.yaml, skills_dir: target/skills, memory_dir: target/memory, agent_kwargs: {reasoning_effort: xhigh}, max_retries: 1}}
   validate: {operator: hyperagents, timeout_s: 300, config: {}}
   gate: {operator: parent_eligible, config: {}}
   record: {operator: hyperagents, config: {}}
@@ -43,5 +43,6 @@ evaluator:
   agent_env:
     MINISWE_STEP_LIMIT: "100"
     MINISWE_REASONING_EFFORT: "high"
-    MINISWE_COST_LIMIT: "0"
+    MINISWE_COST_LIMIT: "3.0"
+    MINISWE_MAX_OUTPUT_LIMIT: "10000"
     MINISWE_ENV_TIMEOUT: "30"

--- a/recipes/hyperagents_codex/evolve.yaml
+++ b/recipes/hyperagents_codex/evolve.yaml
@@ -16,7 +16,7 @@ operators:
   select: {operator: score_child_prop, config: {seed: 0}}
   rollout: {operator: parent_evaluation, timeout_s: 600, config: {field_limit: 2000}}
   analyze: {operator: trace_browser, timeout_s: 600, config: {max_chars: 30000}}
-  mutate: {operator: hyperagents, timeout_s: 21600, config: {runner: harbor, expose_gate_data: false, agent: codex, model: gpt-5.4, environment: docker, image: evolve-mutate-codex:20260818-codex0146, editable_roots: [target, operators], prompt_path: target/prompt.md, skills_dir: target/skills, memory_dir: target/memory, agent_kwargs: {reasoning_effort: high}, max_retries: 1}}
+  mutate: {operator: hyperagents, timeout_s: 21600, config: {runner: harbor, expose_gate_data: false, agent: codex, model: gpt-5.4, environment: docker, image: evolve-mutate-codex:20260818-codex0146, editable_roots: [target, operators], prompt_path: target/prompt.md, skills_dir: target/skills, memory_dir: target/memory, agent_kwargs: {reasoning_effort: xhigh}, max_retries: 1}}
   validate: {operator: hyperagents, timeout_s: 300, config: {}}
   gate: {operator: parent_eligible, config: {}}
   record: {operator: hyperagents, config: {}}

--- a/scripts/setup_terminal_bench.sh
+++ b/scripts/setup_terminal_bench.sh
@@ -19,14 +19,7 @@ cleanup() {
 trap cleanup EXIT
 
 case "$RECIPE" in
-  ahe|hyperagents)
-    IMAGE=evolve-mutate-app:20260724-tools-mswe245
-    IMAGE_CONTEXT=$ROOT/containers/mutate
-    IMAGE_LABEL=io.evolve.miniswe.version
-    IMAGE_VERSION=2.4.5
-    BUILD_ARGS=(--build-arg MINISWE_VERSION=2.4.5)
-    ;;
-  aevolve|ahe_codex|gepa|hill_climb|hill_climb_codex|hyperagents_codex)
+  aevolve|ahe|ahe_codex|gepa|hill_climb|hill_climb_codex|hyperagents|hyperagents_codex)
     IMAGE=evolve-mutate-codex:20260818-codex0146
     IMAGE_CONTEXT=$ROOT/containers/mutate-codex
     IMAGE_LABEL=io.evolve.codex.version

--- a/tests/fixtures/normalized_recipe_operator_configs.json
+++ b/tests/fixtures/normalized_recipe_operator_configs.json
@@ -15,6 +15,9 @@
     },
     "mutate": {
       "agent": "codex",
+      "agent_kwargs": {
+        "reasoning_effort": "xhigh"
+      },
       "editable_roots": [
         "target"
       ],
@@ -67,21 +70,19 @@
     },
     "gate": {},
     "mutate": {
-      "agent": "evolve.integrations.harbor.miniswe_task_file:InstalledMiniSweAgent",
+      "agent": "codex",
       "agent_kwargs": {
-        "cost_limit": 0,
-        "max_tokens": 64000,
-        "reasoning_effort": "high"
+        "reasoning_effort": "xhigh"
       },
       "editable_roots": [
         "target"
       ],
       "environment": "docker",
       "expose_gate_data": false,
-      "image": "evolve-mutate-app:20260724-tools-mswe245",
+      "image": "evolve-mutate-codex:20260818-codex0146",
       "max_retries": 1,
       "memory_dir": "target/memory",
-      "model": "openai/gpt-5.4-2026-03-05",
+      "model": "gpt-5.4",
       "prompt_path": "target/src/minisweagent/config/mini.yaml",
       "runner": "harbor",
       "skills_dir": "target/skills"
@@ -112,7 +113,7 @@
     "mutate": {
       "agent": "codex",
       "agent_kwargs": {
-        "reasoning_effort": "high"
+        "reasoning_effort": "xhigh"
       },
       "editable_roots": [
         "target"
@@ -151,6 +152,9 @@
     "gate": {},
     "mutate": {
       "agent": "codex",
+      "agent_kwargs": {
+        "reasoning_effort": "xhigh"
+      },
       "component_strategy": "round_robin",
       "components": {
         "system_prompt": [
@@ -261,6 +265,9 @@
     },
     "mutate": {
       "agent": "codex",
+      "agent_kwargs": {
+        "reasoning_effort": "xhigh"
+      },
       "editable_roots": [
         "target"
       ],
@@ -301,6 +308,9 @@
     },
     "mutate": {
       "agent": "codex",
+      "agent_kwargs": {
+        "reasoning_effort": "xhigh"
+      },
       "editable_roots": [
         "target"
       ],
@@ -338,11 +348,9 @@
     },
     "gate": {},
     "mutate": {
-      "agent": "evolve.integrations.harbor.miniswe_task_file:InstalledMiniSweAgent",
+      "agent": "codex",
       "agent_kwargs": {
-        "cost_limit": 0,
-        "max_tokens": 64000,
-        "reasoning_effort": "high"
+        "reasoning_effort": "xhigh"
       },
       "editable_roots": [
         "target",
@@ -350,10 +358,10 @@
       ],
       "environment": "docker",
       "expose_gate_data": false,
-      "image": "evolve-mutate-app:20260724-tools-mswe245",
+      "image": "evolve-mutate-codex:20260818-codex0146",
       "max_retries": 1,
       "memory_dir": "target/memory",
-      "model": "openai/gpt-5.4-2026-03-05",
+      "model": "gpt-5.4",
       "prompt_path": "target/src/minisweagent/config/mini.yaml",
       "runner": "harbor",
       "skills_dir": "target/skills"
@@ -378,7 +386,7 @@
     "mutate": {
       "agent": "codex",
       "agent_kwargs": {
-        "reasoning_effort": "high"
+        "reasoning_effort": "xhigh"
       },
       "editable_roots": [
         "target",

--- a/tests/test_ahe_analyze.py
+++ b/tests/test_ahe_analyze.py
@@ -188,8 +188,8 @@ def test_ahe_debugger_reuses_only_allowlisted_mutate_config(tmp_path: Path) -> N
     [
         (
             "ahe",
-            "evolve.integrations.harbor.miniswe_task_file:InstalledMiniSweAgent",
-            "openai/gpt-5.4-2026-03-05",
+            "codex",
+            "gpt-5.4",
         ),
         ("ahe_codex", "codex", "gpt-5.4"),
     ],

--- a/tests/test_hyperagents_harbor_recipe.py
+++ b/tests/test_hyperagents_harbor_recipe.py
@@ -24,16 +24,17 @@ def test_hyperagents_recipe_initializes_broad_harbor_bundle(tmp_path: Path) -> N
     assert "operator: hyperagents" in config
     assert "runner: harbor" in config
     assert "expose_gate_data: false" in config
-    assert "agent: evolve.integrations.harbor.miniswe_task_file:InstalledMiniSweAgent" in config
+    assert "agent: codex" in config
+    assert "reasoning_effort: xhigh" in config
     assert "editable_roots:" in config
     assert "- target" in config and "- operators" in config
     assert "agent_env" not in operator_blocks(workspace)["mutate"]["config"]
     assert json.loads((workspace / ".evolve-components.json").read_text())["integrations"] == [
         "evolve.integrations.harbor.miniswe_candidate",
-        "evolve.integrations.harbor.miniswe_task_file",
     ]
     assert (workspace / "evaluator/agent.env").read_text() == (
-        "MINISWE_COST_LIMIT=0\nMINISWE_ENV_TIMEOUT=30\nMINISWE_REASONING_EFFORT=high\nMINISWE_STEP_LIMIT=100\n"
+        "MINISWE_COST_LIMIT=3.0\nMINISWE_ENV_TIMEOUT=30\nMINISWE_MAX_OUTPUT_LIMIT=10000\n"
+        "MINISWE_REASONING_EFFORT=high\nMINISWE_STEP_LIMIT=100\n"
     )
     assert "task_scope: full" in config
     assert "evaluation_split: train" in config

--- a/tests/test_m9_ahe_recipe.py
+++ b/tests/test_m9_ahe_recipe.py
@@ -55,16 +55,17 @@ def test_ahe_recipe_initializes_harbor_miniswe_composition(tmp_path: Path) -> No
     assert not (workspace / "library/mutate/_support/ahe_manifest.py").exists()
     assert json.loads((workspace / ".evolve-components.json").read_text())["integrations"] == [
         "evolve.integrations.harbor.miniswe_candidate",
-        "evolve.integrations.harbor.miniswe_task_file",
     ]
     assert (workspace / "evaluator/agent.env").read_text() == (
-        "MINISWE_COST_LIMIT=0\nMINISWE_ENV_TIMEOUT=30\nMINISWE_REASONING_EFFORT=high\nMINISWE_STEP_LIMIT=100\n"
+        "MINISWE_COST_LIMIT=3.0\nMINISWE_ENV_TIMEOUT=30\nMINISWE_MAX_OUTPUT_LIMIT=10000\n"
+        "MINISWE_REASONING_EFFORT=high\nMINISWE_STEP_LIMIT=100\n"
     )
     config = (workspace / "evolve.yaml").read_text()
     assert "operator: ahe" in config
     assert "runner: harbor" in config
     assert "expose_gate_data: false" in config
-    assert "agent: evolve.integrations.harbor.miniswe_task_file:InstalledMiniSweAgent" in config
+    assert "agent: codex" in config
+    assert "reasoning_effort: xhigh" in config
     assert "editable_roots:" in config
     operators = operator_blocks(workspace)
     assert "agent_env" not in operators["mutate"]["config"]

--- a/tests/test_phase_e_recipes.py
+++ b/tests/test_phase_e_recipes.py
@@ -20,7 +20,6 @@ UV_SOURCE_RECIPES = {"ahe", "hill_climb", "hyperagents"}
 MAIN_RECIPES = SUPPORTED_RECIPES - {"gepa_local"}
 TERMINAL_BENCH_DATASET = "terminal-bench-2-30-v1"
 CODEX_IMAGE = "evolve-mutate-codex:20260818-codex0146"
-MINISWE_IMAGE = "evolve-mutate-app:20260724-tools-mswe245"
 
 
 def _config(name: str) -> str:
@@ -39,8 +38,7 @@ def test_main_recipes_share_terminal_bench_and_explicit_mutate_images() -> None:
     for name in MAIN_RECIPES:
         config = _parsed_config(name)
         assert config["evaluator"]["dataset"] == TERMINAL_BENCH_DATASET
-        expected_image = MINISWE_IMAGE if name in {"ahe", "hyperagents"} else CODEX_IMAGE
-        assert _operator_config(name, "mutate")["image"] == expected_image
+        assert _operator_config(name, "mutate")["image"] == CODEX_IMAGE
 
 
 def test_all_recipes_are_recipe_artifacts_only() -> None:
@@ -177,20 +175,14 @@ def test_supported_recipes_use_harbor_and_method_mutate() -> None:
             assert mutate["agent"] == "evolve.integrations.harbor.local_auto_agent:LocalAutoAgent"
         elif name in {"ahe", "hyperagents"}:
             assert config["target"]["revision"] == "388da74aad620a384ab47669b17c52133e30e7c3"
-            assert mutate["agent"] == "evolve.integrations.harbor.miniswe_task_file:InstalledMiniSweAgent"
+            assert mutate["agent"] == "codex"
         else:
             assert mutate["agent"] == "codex"
 
 
-def test_ahe_and_hyperagents_share_the_pinned_mutate_image() -> None:
-    expected = "evolve-mutate-app:20260724-tools-mswe245"
-    for name in ("ahe", "hyperagents"):
-        assert _operator_config(name, "mutate")["image"] == expected
-
-
 def test_codex_mutates_use_the_preinstalled_codex_image() -> None:
     expected = "evolve-mutate-codex:20260818-codex0146"
-    for name in ("aevolve", "ahe_codex", "gepa", "hill_climb", "hill_climb_codex", "hyperagents_codex"):
+    for name in MAIN_RECIPES:
         assert _operator_config(name, "mutate")["image"] == expected
 
 
@@ -259,12 +251,12 @@ def test_all_explicit_recipe_retry_and_multiplier_values_are_one() -> None:
         assert "infra_repair_attempts" not in _config(name)
 
 
-def test_miniswe_method_agents_use_the_rollout_model_version() -> None:
+def test_miniswe_targets_and_codex_mutators_use_the_benchmark_models() -> None:
     expected_model = "openai/gpt-5.4-2026-03-05"
     for name in ("ahe", "hyperagents"):
         config = _parsed_config(name)
         mutate = _operator_config(name, "mutate")
-        assert mutate["model"] == expected_model
+        assert mutate["model"] == "gpt-5.4"
         evaluator = config["evaluator"]
         assert isinstance(evaluator, dict)
         assert evaluator["model"] == expected_model
@@ -332,31 +324,33 @@ def test_codex_mutate_image_pins_the_mutator_cli_version() -> None:
     assert "git config --system --add safe.directory /app/task/workspace" in dockerfile
 
 
-def test_ahe_recipe_configures_reasoning_without_cost_caps() -> None:
+def test_ahe_recipe_matches_reported_miniswe_target_limits() -> None:
     recipe = _parsed_config("ahe")
-    assert _operator_config("ahe", "mutate")["agent_kwargs"] == {
-        "reasoning_effort": "high",
-        "cost_limit": 0,
-        "max_tokens": 64_000,
-    }
+    assert _operator_config("ahe", "mutate")["agent_kwargs"] == {"reasoning_effort": "xhigh"}
     assert recipe["evaluator"]["agent_env"]["MINISWE_REASONING_EFFORT"] == "high"
-    assert recipe["evaluator"]["agent_env"]["MINISWE_COST_LIMIT"] == "0"
+    assert recipe["evaluator"]["agent_env"]["MINISWE_COST_LIMIT"] == "3.0"
+    assert recipe["evaluator"]["agent_env"]["MINISWE_MAX_OUTPUT_LIMIT"] == "10000"
 
 
-def test_hyperagents_recipe_configures_reasoning_without_cost_caps() -> None:
+def test_hyperagents_recipe_matches_reported_miniswe_target_limits() -> None:
     recipe = _parsed_config("hyperagents")
-    assert _operator_config("hyperagents", "mutate")["agent_kwargs"] == {
-        "reasoning_effort": "high",
-        "cost_limit": 0,
-        "max_tokens": 64_000,
-    }
+    assert _operator_config("hyperagents", "mutate")["agent_kwargs"] == {"reasoning_effort": "xhigh"}
     assert "budget_usd" not in recipe["experiment"]
     assert recipe["evaluator"]["agent_env"] == {
-        "MINISWE_COST_LIMIT": "0",
+        "MINISWE_COST_LIMIT": "3.0",
         "MINISWE_ENV_TIMEOUT": "30",
+        "MINISWE_MAX_OUTPUT_LIMIT": "10000",
         "MINISWE_REASONING_EFFORT": "high",
         "MINISWE_STEP_LIMIT": "100",
     }
+
+
+def test_benchmark_mutators_use_codex_xhigh() -> None:
+    for name in MAIN_RECIPES:
+        mutate = _operator_config(name, "mutate")
+        assert mutate["agent"] == "codex"
+        assert mutate["model"] == "gpt-5.4"
+        assert mutate["agent_kwargs"] == {"reasoning_effort": "xhigh"}
 
 
 def test_recipe_retry_and_partial_floor_defaults_remain_method_specific() -> None:

--- a/tests/test_recipe_composition.py
+++ b/tests/test_recipe_composition.py
@@ -21,16 +21,18 @@ from evolve.config import (
 from evolve.workspace import InitOptions, _write_target, init_workspace
 
 CANDIDATE = "evolve.integrations.harbor.miniswe_candidate:CandidateMiniSweAgent"
-OPTIONAL_INTEGRATIONS = {"evolve.integrations.harbor.codex_candidate"}
-FILE_TASK = "evolve.integrations.harbor.miniswe_task_file:InstalledMiniSweAgent"
+OPTIONAL_INTEGRATIONS = {
+    "evolve.integrations.harbor.codex_candidate",
+    "evolve.integrations.harbor.miniswe_task_file",
+}
 ANSI_ESCAPE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
 CASES = {
     "hill_climb": ("external", CANDIDATE, "codex"),
     "aevolve": ("codex", "target.agent:HarborAgent", "codex"),
-    "ahe": ("external", CANDIDATE, FILE_TASK),
+    "ahe": ("external", CANDIDATE, "codex"),
     "ahe_codex": ("codex", "target.agent:HarborAgent", "codex"),
     "gepa": ("codex", "target.agent:HarborAgent", "codex"),
-    "hyperagents": ("external", CANDIDATE, FILE_TASK),
+    "hyperagents": ("external", CANDIDATE, "codex"),
     "hill_climb_codex": ("codex", "target.agent:HarborAgent", "codex"),
     "hyperagents_codex": ("codex", "target.agent:HarborAgent", "codex"),
 }

--- a/tests/test_terminal_bench_setup_script.py
+++ b/tests/test_terminal_bench_setup_script.py
@@ -155,7 +155,7 @@ def test_setup_rejects_an_existing_incomplete_raw_directory(tmp_path: Path) -> N
     assert not any(call[0:5] == ["uv", "run", "--frozen", "harbor", "download"] for call in _calls(calls_path))
 
 
-def test_setup_downloads_once_and_builds_miniswe_image_for_ahe(tmp_path: Path) -> None:
+def test_setup_downloads_once_and_builds_codex_image_for_ahe(tmp_path: Path) -> None:
     environment, calls_path = _environment(tmp_path)
 
     first = subprocess.run(
@@ -181,7 +181,7 @@ def test_setup_downloads_once_and_builds_miniswe_image_for_ahe(tmp_path: Path) -
     )
     builds = [call for call in calls if call[:2] == ["docker", "build"]]
     assert len(builds) == 1
-    assert "evolve-mutate-app:20260724-tools-mswe245" in builds[0]
+    assert "evolve-mutate-codex:20260818-codex0146" in builds[0]
     assert "./scripts/run_recipe_demo.sh ahe" in second.stdout
 
 


### PR DESCRIPTION
## Summary
- align benchmark recipe mutation agents on Codex CLI 0.146.0 with xhigh reasoning
- keep MiniSWE and Codex targets on the versions, models, reasoning, and limits used by the reported TB2 experiments
- update Terminal-Bench setup, recipe docs, and compatibility snapshots

## Validation
- 8 benchmark recipe checks passed
- 91 relevant tests passed
- ruff check passed
- ruff format --check passed
- ty check passed
- bash -n scripts/setup_terminal_bench.sh passed
- git diff --check passed
- verified evolve-mutate-codex:20260818-codex0146 reports codex-cli 0.146.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated benchmark recipes to use Codex CLI 0.146.0 with `xhigh` reasoning.
  * Migrated AHE and HyperAgents mutation workflows to the Codex-based runner.
  * Added updated evaluator limits, including cost and output controls.
  * Streamlined setup instructions with the new pinned Codex image.

* **Tests**
  * Updated recipe validation and setup checks for the new Codex configuration and image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->