### PR TITLE
fix: align benchmark agent settings and enforce MiniSWE output budget

### DIFF
--- a/src/evolve/integrations/harbor/miniswe_candidate.py
+++ b/src/evolve/integrations/harbor/miniswe_candidate.py
@@ -69,6 +69,23 @@ def _reasoning_effort():
     return effort
 
 
+def _max_output_tokens():
+    raw = os.environ.get("MINISWE_MAX_OUTPUT_LIMIT", "").strip()
+    if not raw:
+        return None
+    try:
+        value = int(raw)
+    except ValueError as error:
+        raise ValueError(
+            f"Invalid MINISWE_MAX_OUTPUT_LIMIT={raw!r}; expected a positive integer"
+        ) from error
+    if value <= 0:
+        raise ValueError(
+            f"Invalid MINISWE_MAX_OUTPUT_LIMIT={raw!r}; expected a positive integer"
+        )
+    return value
+
+
 def build_model(config):
     model_name = os.environ["MSWEA_MODEL_NAME"]
     effort = _reasoning_effort()
@@ -78,7 +95,11 @@ def build_model(config):
 
     if model_name.startswith("openai/"):
         nested_kwargs = dict(model_kwargs.get("model_kwargs") or {})
-        nested_kwargs.setdefault("max_output_tokens", 64_000)
+        output_limit = _max_output_tokens()
+        if output_limit is None:
+            nested_kwargs.setdefault("max_output_tokens", 64_000)
+        else:
+            nested_kwargs["max_output_tokens"] = output_limit
         nested_kwargs.pop("reasoning_effort", None)
         if effort is not None:
             nested_kwargs["reasoning"] = {"effort": effort}
@@ -519,6 +540,7 @@ class CandidateMiniSweAgent(MiniSweAgent):
         for name in (
             "MINISWE_STEP_LIMIT",
             "MINISWE_COST_LIMIT",
+            "MINISWE_MAX_OUTPUT_LIMIT",
             "MINISWE_ENV_TIMEOUT",
             "MINISWE_REASONING_EFFORT",
         ):

--- a/tests/test_miniswe_harbor_wrapper.py
+++ b/tests/test_miniswe_harbor_wrapper.py
@@ -166,6 +166,16 @@ def test_miniswe_wrapper_forwards_reasoning_effort(adapter_path: Path, monkeypat
     assert "MINISWE_REASONING_EFFORT" not in module.MiniSweSourceAgent()._source_env()
 
 
+def test_miniswe_wrapper_forwards_max_output_limit(adapter_path: Path, monkeypatch) -> None:
+    _install_fake_harbor(monkeypatch)
+    module = _load(adapter_path)
+    monkeypatch.setenv("MINISWE_MAX_OUTPUT_LIMIT", "10000")
+
+    source_env = module.MiniSweSourceAgent()._source_env()
+
+    assert source_env["MINISWE_MAX_OUTPUT_LIMIT"] == "10000"
+
+
 def test_miniswe_wrapper_source_environment_contains_only_strings(adapter_path: Path, monkeypatch) -> None:
     _install_fake_harbor(monkeypatch)
     module = _load(adapter_path)
@@ -255,6 +265,27 @@ def test_miniswe_wrapper_preserves_explicit_responses_output_budget(adapter_path
 
     assert type(model) is FakeLitellmResponseModel
     assert model.kwargs["model_kwargs"]["max_output_tokens"] == 12_345
+
+
+def test_miniswe_wrapper_runtime_output_limit_overrides_candidate_config(adapter_path: Path, monkeypatch) -> None:
+    _, build_model, (_, FakeLitellmResponseModel) = _load_model_factory(adapter_path, monkeypatch)
+    monkeypatch.setenv("MSWEA_MODEL_NAME", "openai/gpt-5.4")
+    monkeypatch.setenv("MINISWE_MAX_OUTPUT_LIMIT", "10000")
+
+    model = build_model({"model": {"model_kwargs": {"max_output_tokens": 64_000}}})
+
+    assert type(model) is FakeLitellmResponseModel
+    assert model.kwargs["model_kwargs"]["max_output_tokens"] == 10_000
+
+
+@pytest.mark.parametrize("value", ["0", "-1", "invalid"])
+def test_miniswe_wrapper_rejects_invalid_runtime_output_limit(adapter_path: Path, monkeypatch, value: str) -> None:
+    _, build_model, _ = _load_model_factory(adapter_path, monkeypatch)
+    monkeypatch.setenv("MSWEA_MODEL_NAME", "openai/gpt-5.4")
+    monkeypatch.setenv("MINISWE_MAX_OUTPUT_LIMIT", value)
+
+    with pytest.raises(ValueError, match="expected a positive integer"):
+        build_model({"model": {}})
 
 
 def test_miniswe_wrapper_uses_responses_without_openai_reasoning(adapter_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
Aligns benchmark recipes with the audited target/mutation agent settings and makes `MINISWE_MAX_OUTPUT_LIMIT` an enforced runtime override in the candidate adapter.

Validation:
- 63 targeted adapter/recipe tests passed
- repository-wide Ruff, format, and ty checks passed
- end-to-end runtime canaries recorded `max_output_tokens=10000`, `cost_limit=3.0`, and `reasoning.effort=high`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring the maximum model output length through the `MINISWE_MAX_OUTPUT_LIMIT` environment setting.
  - OpenAI-based models now use the configured limit, with a default maximum applied when no setting is provided.

- **Bug Fixes**
  - Invalid limits, including zero, negative, or non-numeric values, are now rejected with a clear validation error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->