### PR TITLE
docs: map the diagram's loop phases to the registered operator stages

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,25 +89,31 @@ Every recipe composes the same loop:
 
 A recipe decides how parent nodes are selected, how traces are analyzed, what
 may be edited, and which evaluations admit a new generation. The framework owns
-the two stages that make those decisions inspectable, and executes every trial
+the two phases that make those decisions inspectable, and executes every trial
 on [Harbor](https://github.com/harbor-framework/harbor), which provides
 container execution, trajectory capture, and per-task verification.
 
-| Stage | Owned by | What happens |
-| --- | --- | --- |
-| `select` | recipe | Choose an eligible parent node from the archive and fork its exact commit. |
-| `rollout` | recipe | Run the parent node on the training split and return execution evidence. |
-| `analyze` | recipe | Distill rollout traces into bounded mutation evidence. |
-| `mutate` | recipe | Propose edits inside the declared mutable surface. |
-| `guardrail` | **framework** | Check the actual diff against that surface and reject out-of-bounds proposals. |
-| `evaluate` | **framework** | Score a clean checkout of the reviewed candidate agent and certify the outcome. |
-| `absorb` | recipe | Decide admission, record annotations, and carry lineage forward. |
+The diagram labels the seven **phases** of the loop. Operators plug into nine
+named **stages** — five required (`select`, `rollout`, `mutate`, `gate`,
+`record`) and four optional, marked `*` below (`analyze`, `validate`, `novelty`,
+`reflect`). Three phases group more than one stage, which is why the two
+vocabularies differ:
+
+| Phase | Owned by | Stages that run here | What happens |
+| --- | --- | --- | --- |
+| `select` | recipe | `select` | Choose an eligible parent node from the archive and fork its exact commit. |
+| `rollout` | recipe | `rollout` | Run the parent node on the training split and return execution evidence. |
+| `analyze` | recipe | `analyze`* | Distill rollout traces into bounded mutation evidence. |
+| `mutate` | recipe | `mutate` | Propose edits inside the declared mutable surface. |
+| `guardrail` | **framework** | `validate`*, `novelty`* | Check the actual tree diff against the mutable surface. The two optional operators may then reject the proposal: `validate` applies a method-specific pre-evaluation check, `novelty` drops near-duplicates. |
+| `evaluate` | **framework** | none | Commit the reviewed tree, score a clean checkout, certify the outcome. No recipe-selected operator runs here. |
+| `absorb` | recipe | `gate`, `record`, `reflect`* | `gate` decides from the certified score whether the child becomes a parent, `record` proposes annotations, `reflect` distills insights for later generations. |
 
 Three terms cover the composition model:
 
 | Term | Meaning |
 | --- | --- |
-| `stage` | A fixed lifecycle slot — one row of the table above. |
+| `stage` | One fixed lifecycle slot, named exactly as registered: `select`, `rollout`, `analyze`, `mutate`, `validate`, `novelty`, `gate`, `record`, `reflect`. |
 | `operator` | One reusable implementation of a stage, at `library/<stage>/<name>.py`. |
 | `recipe` | Code-free selection and configuration of those operators. |
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -85,25 +85,30 @@ RSIHub 为 agent 提供了一条受控的自我改进路径。它让候选 agent
 </p>
 
 recipe 决定：如何挑选父结点、如何分析轨迹、哪些文件允许被编辑、以及什么样的评测结果才能让新一代通过。
-框架独占其中两个阶段，让这些决策可被检验；所有试验都在
+框架独占其中两个 phase，让这些决策可被检验；所有试验都在
 [Harbor](https://github.com/harbor-framework/harbor) 上执行，由它提供容器化运行、轨迹捕获与逐任务验证。
 
-| 阶段 | 归属 | 做什么 |
-| --- | --- | --- |
-| `select` | recipe | 从归档中挑选一个合格的父结点，并检出它确切的那次 commit。 |
-| `rollout` | recipe | 在训练集上运行父结点，返回执行证据。 |
-| `analyze` | recipe | 把 rollout 轨迹提炼为范围受限的 mutation 依据。 |
-| `mutate` | recipe | 在声明过的 surface 内提出修改。 |
-| `guardrail` | **框架** | 用实际 diff 比对 surface，拒绝越界的修改提案。 |
-| `evaluate` | **框架** | 对审查后的候选 agent 做一次干净检出并打分，认证结果。 |
-| `absorb` | recipe | 决定是否准入、写入标注、并延续 lineage。 |
+图中标注的是主循环的七个 **phase（阶段）**。operator 挂载的则是九个具名的 **stage**——
+五个必需（`select`、`rollout`、`mutate`、`gate`、`record`），四个可选（下表中以 `*` 标记：
+`analyze`、`validate`、`novelty`、`reflect`）。有三个 phase 包含不止一个 stage，
+这也是两套名字对不上的原因：
+
+| Phase | 归属 | 在此运行的 stage | 做什么 |
+| --- | --- | --- | --- |
+| `select` | recipe | `select` | 从归档中挑选一个合格的父结点，并检出它确切的那次 commit。 |
+| `rollout` | recipe | `rollout` | 在训练集上运行父结点，返回执行证据。 |
+| `analyze` | recipe | `analyze`* | 把 rollout 轨迹提炼为范围受限的 mutation 依据。 |
+| `mutate` | recipe | `mutate` | 在声明过的 surface 内提出修改。 |
+| `guardrail` | **框架** | `validate`*、`novelty`* | 用实际的 tree diff 比对 surface。随后这两个可选 operator 可以否决提案：`validate` 施加方法特定的预评测检查，`novelty` 丢弃近似重复的改动。 |
+| `evaluate` | **框架** | 无 | 提交审查后的 tree，对干净检出打分并认证结果。此处不运行任何 recipe 选定的 operator。 |
+| `absorb` | recipe | `gate`、`record`、`reflect`* | `gate` 依据认证过的分数决定 child 是否成为 parent，`record` 提出标注，`reflect` 提炼供后续代际使用的洞见。 |
 
 理解组合模型只需三个术语：
 
 | 术语 | 含义 |
 | --- | --- |
-| `stage` 阶段 | 固定的生命周期槽位——即上表中的一行。 |
-| `operator` | 某个阶段的一份可复用实现，位于 `library/<stage>/<name>.py`。 |
+| `stage` 阶段 | 固定的生命周期槽位，名称与注册名严格一致：`select`、`rollout`、`analyze`、`mutate`、`validate`、`novelty`、`gate`、`record`、`reflect`。 |
+| `operator` | 某个 stage 的一份可复用实现，位于 `library/<stage>/<name>.py`。 |
 | `recipe` | 对这些 operator 的免代码选择与配置。 |
 
 evaluate 永远不是可选的 operator——它由框架独占。operator 的编写、校验与组合方式见


### PR DESCRIPTION
The README named `guardrail`, `evaluate`, and `absorb` in a table headed "Stage", next to a definition pointing at `library/<stage>/<name>.py`. Those three are phases in the architecture diagram, not registered stages: `library/` and docs/reference/terminology.md define exactly nine — select, rollout, analyze, mutate, validate, novelty, gate, record, reflect — so a contributor following the README would look for a `guardrail` slot that does not exist.

Keep the diagram and its seven phase labels unchanged, and reconcile the two vocabularies in the text instead:

- Rename the column to "Phase" and add a "Stages that run here" column, so `guardrail` maps to `validate` + `novelty`, `evaluate` to none, and `absorb` to `gate` + `record` + `reflect`.
- State the five required and four optional operator interfaces, following the paper's wording for each phase.
- Correct the `stage` glossary row to the nine registered names, matching docs/reference/terminology.md.

Applied to both README.md and README.zh-CN.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the English and Simplified Chinese guides to distinguish the seven lifecycle phases from the nine named stages.
  * Added ownership and stage-mapping details to the workflow tables.
  * Clarified framework-owned and recipe-owned stages.
  * Expanded terminology guidance for stages, operators, and recipes.
  * Documented optional `validate`, `novelty`, and `reflect` stages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->