### PR TITLE
docs: add a language switcher to both READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,13 @@
   <a href="#documentation">Documentation</a>
 </p>
 
+<p align="center">
+  <img alt="English" src="https://img.shields.io/badge/English-0F766E?style=for-the-badge&amp;logo=googletranslate&amp;logoColor=white">
+  <a href="README.zh-CN.md">
+    <img alt="简体中文" src="https://img.shields.io/badge/%E7%AE%80%E4%BD%93%E4%B8%AD%E6%96%87-555555?style=for-the-badge">
+  </a>
+</p>
+
 > [!TIP]
 > **New to AI-for-AI and agent self-improvement?** Start with the curated
 > [Awesome-AI4AI](https://github.com/KaiWU5/Awesome-AI4AI) paper list, read the

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -42,7 +42,10 @@
 </p>
 
 <p align="center">
-  <a href="README.md">English</a> · <strong>简体中文</strong>
+  <a href="README.md">
+    <img alt="English" src="https://img.shields.io/badge/English-555555?style=for-the-badge">
+  </a>
+  <img alt="简体中文" src="https://img.shields.io/badge/%E7%AE%80%E4%BD%93%E4%B8%AD%E6%96%87-0F766E?style=for-the-badge&amp;logo=googletranslate&amp;logoColor=white">
 </p>
 
 > [!TIP]


### PR DESCRIPTION
## What

Adds a pair of shields.io badge buttons near the top of both READMEs so
readers can switch between the English and Simplified Chinese versions.

## Why

`README.zh-CN.md` already linked back to the English README, but
`README.md` had no link to the translation at all — the Chinese README was
effectively unreachable from the repository landing page, which is where
most readers arrive.

## Details

- The badge for the page you are currently on is teal (`0F766E`, matching
  the existing Documentation badge) and carries the translate glyph; it is
  intentionally not a link.
- The other language is a grey (`555555`) clickable badge.
- Placement is identical in both files: directly below the section-nav
  line, matching where the Chinese README already had its text switcher.
- Docs-only change; no code or tests touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added a language switcher to the English README header, with an active English badge and a link to the Simplified Chinese translation.
  - Updated the Simplified Chinese README header to use badge-style language links, including a link back to the English README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->