### PR TITLE
fix(docs): link the active language badge to its own README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@
 </p>
 
 <p align="center">
-  <img alt="English" src="https://img.shields.io/badge/English-0F766E?style=for-the-badge&amp;logo=googletranslate&amp;logoColor=white">
+  <a href="README.md">
+    <img alt="English" src="https://img.shields.io/badge/English-0F766E?style=for-the-badge&amp;logo=googletranslate&amp;logoColor=white">
+  </a>
   <a href="README.zh-CN.md">
     <img alt="简体中文" src="https://img.shields.io/badge/%E7%AE%80%E4%BD%93%E4%B8%AD%E6%96%87-555555?style=for-the-badge">
   </a>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -45,7 +45,9 @@
   <a href="README.md">
     <img alt="English" src="https://img.shields.io/badge/English-555555?style=for-the-badge">
   </a>
-  <img alt="简体中文" src="https://img.shields.io/badge/%E7%AE%80%E4%BD%93%E4%B8%AD%E6%96%87-0F766E?style=for-the-badge&amp;logo=googletranslate&amp;logoColor=white">
+  <a href="README.zh-CN.md">
+    <img alt="简体中文" src="https://img.shields.io/badge/%E7%AE%80%E4%BD%93%E4%B8%AD%E6%96%87-0F766E?style=for-the-badge&amp;logo=googletranslate&amp;logoColor=white">
+  </a>
 </p>
 
 > [!TIP]


### PR DESCRIPTION
GitHub wraps any README image that is not already inside a link with a link to the image file itself. The current-language badge was a bare <img>, so clicking it navigated to the badge SVG on camo instead of staying on the page. Linking it to its own file keeps GitHub from auto-linking it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the README language-switcher badges so both English and Simplified Chinese badges link to their respective documentation pages.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->